### PR TITLE
Level 2 Data

### DIFF
--- a/crates/order_book/examples/order_book/main.rs
+++ b/crates/order_book/examples/order_book/main.rs
@@ -3,10 +3,14 @@ use bourse_book::{types, OrderBook};
 fn main() {
     let mut book = OrderBook::new(0, 1, true);
 
-    book.create_and_place_order(types::Side::Ask, 20, 0, Some(60));
-    book.create_and_place_order(types::Side::Ask, 20, 0, Some(65));
-    book.create_and_place_order(types::Side::Bid, 10, 0, Some(50));
-    book.create_and_place_order(types::Side::Bid, 10, 0, Some(45));
+    book.create_and_place_order(types::Side::Ask, 20, 0, Some(60))
+        .unwrap();
+    book.create_and_place_order(types::Side::Ask, 20, 0, Some(65))
+        .unwrap();
+    book.create_and_place_order(types::Side::Bid, 10, 0, Some(50))
+        .unwrap();
+    book.create_and_place_order(types::Side::Bid, 10, 0, Some(45))
+        .unwrap();
 
     let (bid, ask) = book.bid_ask();
 
@@ -18,7 +22,7 @@ fn main() {
         book.ask_vol()
     );
 
-    let id_e = book.create_order(types::Side::Ask, 15, 99, None);
+    let id_e = book.create_order(types::Side::Ask, 15, 99, None).unwrap();
 
     book.set_time(10);
     book.place_order(id_e);

--- a/crates/order_book/examples/order_book/main.rs
+++ b/crates/order_book/examples/order_book/main.rs
@@ -1,7 +1,7 @@
 use bourse_book::{types, OrderBook};
 
 fn main() {
-    let mut book = OrderBook::new(0, 1, true);
+    let mut book: OrderBook = OrderBook::new(0, 1, true);
 
     book.create_and_place_order(types::Side::Ask, 20, 0, Some(60))
         .unwrap();

--- a/crates/order_book/examples/order_book/main.rs
+++ b/crates/order_book/examples/order_book/main.rs
@@ -1,17 +1,12 @@
 use bourse_book::{types, OrderBook};
 
 fn main() {
-    let mut book = OrderBook::new(0, true);
+    let mut book = OrderBook::new(0, 1, true);
 
-    let id_a = book.create_order(types::Side::Ask, 20, 0, Some(60));
-    let id_b = book.create_order(types::Side::Ask, 20, 0, Some(65));
-    let id_c = book.create_order(types::Side::Bid, 10, 0, Some(50));
-    let id_d = book.create_order(types::Side::Bid, 10, 0, Some(45));
-
-    book.place_order(id_a);
-    book.place_order(id_b);
-    book.place_order(id_c);
-    book.place_order(id_d);
+    book.create_and_place_order(types::Side::Ask, 20, 0, Some(60));
+    book.create_and_place_order(types::Side::Ask, 20, 0, Some(65));
+    book.create_and_place_order(types::Side::Bid, 10, 0, Some(50));
+    book.create_and_place_order(types::Side::Bid, 10, 0, Some(45));
 
     let (bid, ask) = book.bid_ask();
 

--- a/crates/order_book/src/lib.rs
+++ b/crates/order_book/src/lib.rs
@@ -14,7 +14,7 @@
 //! use bourse_book;
 //! use bourse_book::types;
 //!
-//! let mut book = bourse_book::OrderBook::new(0, true);
+//! let mut book = bourse_book::OrderBook::new(0, 1, true);
 //!
 //! // Create a new order
 //! let order_id = book.create_order(
@@ -47,7 +47,7 @@
 //! ```
 //! # use bourse_book::OrderBook;
 //! # use bourse_book::types::{Order, Trade};
-//! # let book = OrderBook::new(0, true);
+//! # let book = OrderBook::new(0, 1, true);
 //! // Get references to all the orders created
 //! let order_history: Vec<&Order> = book.get_orders();
 //! // Get a reference to trade records
@@ -63,7 +63,7 @@
 //!
 //! ```
 //! # use bourse_book::OrderBook;
-//! # let book = OrderBook::new(0, true);
+//! # let book = OrderBook::new(0, 1, true);
 //! let state = serde_json::to_string(&book).unwrap();
 //! let book = serde_json::from_str::<OrderBook>(state.as_str()).unwrap();
 //! ```
@@ -72,7 +72,7 @@
 //!
 //! ```no_run
 //! # use bourse_book::OrderBook;
-//! # let book = OrderBook::new(0, true);
+//! # let book = OrderBook::new(0, 1, true);
 //! book.save_json("foo.json", true);
 //! let loaded_book = OrderBook::load_json("foo.json");
 //! ```

--- a/crates/order_book/src/lib.rs
+++ b/crates/order_book/src/lib.rs
@@ -19,7 +19,7 @@
 //! // Create a new order
 //! let order_id = book.create_order(
 //!     types::Side::Bid, 50, 101, Some(50)
-//! );
+//! ).unwrap();
 //!
 //! // Place the order on the market
 //! book.place_order(order_id);
@@ -98,4 +98,4 @@ mod orderbook;
 mod side;
 pub mod types;
 
-pub use orderbook::OrderBook;
+pub use orderbook::{OrderBook, OrderError};

--- a/crates/order_book/src/lib.rs
+++ b/crates/order_book/src/lib.rs
@@ -12,9 +12,9 @@
 //!
 //! ```
 //! use bourse_book;
-//! use bourse_book::types;
+//! use bourse_book::{types, OrderBook};
 //!
-//! let mut book = bourse_book::OrderBook::new(0, 1, true);
+//! let mut book: OrderBook = OrderBook::new(0, 1, true);
 //!
 //! // Create a new order
 //! let order_id = book.create_order(
@@ -47,7 +47,7 @@
 //! ```
 //! # use bourse_book::OrderBook;
 //! # use bourse_book::types::{Order, Trade};
-//! # let book = OrderBook::new(0, 1, true);
+//! # let book: OrderBook = OrderBook::new(0, 1, true);
 //! // Get references to all the orders created
 //! let order_history: Vec<&Order> = book.get_orders();
 //! // Get a reference to trade records
@@ -63,7 +63,7 @@
 //!
 //! ```
 //! # use bourse_book::OrderBook;
-//! # let book = OrderBook::new(0, 1, true);
+//! # let book: OrderBook = OrderBook::new(0, 1, true);
 //! let state = serde_json::to_string(&book).unwrap();
 //! let book = serde_json::from_str::<OrderBook>(state.as_str()).unwrap();
 //! ```
@@ -72,9 +72,9 @@
 //!
 //! ```no_run
 //! # use bourse_book::OrderBook;
-//! # let book = OrderBook::new(0, 1, true);
+//! # let book: OrderBook = OrderBook::new(0, 1, true);
 //! book.save_json("foo.json", true);
-//! let loaded_book = OrderBook::load_json("foo.json");
+//! let loaded_book: OrderBook = OrderBook::load_json("foo.json").unwrap();
 //! ```
 //!
 //! # Notes

--- a/crates/order_book/src/orderbook.rs
+++ b/crates/order_book/src/orderbook.rs
@@ -1058,6 +1058,38 @@ mod tests {
     }
 
     #[test]
+    fn test_incorrect_price_err() {
+        let mut book = OrderBook::new(0, 2, true);
+
+        let res = book.create_order(Side::Ask, 100, 101, Some(51));
+
+        assert!(res.is_err_and(|e| matches!(
+            e,
+            OrderError::PriceError {
+                price: 51,
+                tick_size: 2
+            }
+        )));
+    }
+
+    #[test]
+    fn test_no_double_place() {
+        let mut book = OrderBook::new(0, 2, true);
+
+        let id = book.create_order(Side::Ask, 100, 101, Some(50)).unwrap();
+
+        book.place_order(id);
+
+        assert!(book.bid_ask() == (0, 50));
+        assert!(book.ask_best_vol_and_orders() == (100, 1));
+
+        book.place_order(id);
+
+        assert!(book.bid_ask() == (0, 50));
+        assert!(book.ask_best_vol_and_orders() == (100, 1));
+    }
+
+    #[test]
     fn test_serialisation() {
         use rand::{seq::SliceRandom, Rng};
         use rand_xoshiro::rand_core::SeedableRng;

--- a/crates/order_book/src/side.rs
+++ b/crates/order_book/src/side.rs
@@ -27,6 +27,8 @@ pub trait SideFunctionality {
     fn vol(&self) -> Vol;
     /// Get the id of the highest priority order
     fn best_order_idx(&self) -> Option<OrderId>;
+    /// Get the volume and orders at a price level
+    fn vol_and_orders_at_price(&self, price: &Price) -> (Vol, OrderCount);
 }
 
 /// Order book side data structure
@@ -126,6 +128,19 @@ impl OrderBookSide {
     fn best_order_idx(&self) -> Option<OrderId> {
         self.orders.first_key_value().map(|(_, v)| *v)
     }
+
+    /// Get volume and numbers of orders at a price level
+    ///
+    /// # Arguments
+    ///
+    /// - `price` - Price level to retrieve data for
+    ///
+    fn vol_and_orders_at_price(&self, price: &Price) -> (Vol, OrderCount) {
+        match self.volumes.get(price) {
+            Some(x) => *x,
+            None => (0, 0),
+        }
+    }
 }
 
 /// Bid-side specific functionality
@@ -199,6 +214,10 @@ impl SideFunctionality for BidSide {
     fn best_order_idx(&self) -> Option<OrderId> {
         self.0.best_order_idx()
     }
+
+    fn vol_and_orders_at_price(&self, price: &Price) -> (Vol, OrderCount) {
+        self.0.vol_and_orders_at_price(price)
+    }
 }
 
 impl SideFunctionality for AskSide {
@@ -263,6 +282,10 @@ impl SideFunctionality for AskSide {
     /// Get the index of the best ask order
     fn best_order_idx(&self) -> Option<OrderId> {
         self.0.best_order_idx()
+    }
+
+    fn vol_and_orders_at_price(&self, price: &Price) -> (Vol, OrderCount) {
+        self.0.vol_and_orders_at_price(price)
     }
 }
 
@@ -429,5 +452,18 @@ mod tests {
         assert!(side.best_vol() == 5);
         assert!(side.best_vol_and_orders() == (5, 1));
         assert!(side.vol() == 5);
+    }
+
+    #[test]
+    fn test_vol_and_orders_at_price() {
+        let mut side = AskSide::new();
+
+        side.insert_order(get_ask_key(0, 100), 1, 10);
+        side.insert_order(get_ask_key(1, 100), 2, 20);
+        side.insert_order(get_ask_key(1, 101), 3, 40);
+
+        assert!(side.vol_and_orders_at_price(&100) == (30, 2));
+        assert!(side.vol_and_orders_at_price(&101) == (40, 1));
+        assert!(side.vol_and_orders_at_price(&102) == (0, 0));
     }
 }

--- a/crates/order_book/src/side.rs
+++ b/crates/order_book/src/side.rs
@@ -28,7 +28,7 @@ pub trait SideFunctionality {
     /// Get the id of the highest priority order
     fn best_order_idx(&self) -> Option<OrderId>;
     /// Get the volume and orders at a price level
-    fn vol_and_orders_at_price(&self, price: &Price) -> (Vol, OrderCount);
+    fn vol_and_orders_at_price(&self, price: Price) -> (Vol, OrderCount);
 }
 
 /// Order book side data structure
@@ -135,8 +135,8 @@ impl OrderBookSide {
     ///
     /// - `price` - Price level to retrieve data for
     ///
-    fn vol_and_orders_at_price(&self, price: &Price) -> (Vol, OrderCount) {
-        match self.volumes.get(price) {
+    fn vol_and_orders_at_price(&self, price: Price) -> (Vol, OrderCount) {
+        match self.volumes.get(&price) {
             Some(x) => *x,
             None => (0, 0),
         }
@@ -215,7 +215,8 @@ impl SideFunctionality for BidSide {
         self.0.best_order_idx()
     }
 
-    fn vol_and_orders_at_price(&self, price: &Price) -> (Vol, OrderCount) {
+    fn vol_and_orders_at_price(&self, price: Price) -> (Vol, OrderCount) {
+        let price = Price::MAX - price;
         self.0.vol_and_orders_at_price(price)
     }
 }
@@ -284,7 +285,7 @@ impl SideFunctionality for AskSide {
         self.0.best_order_idx()
     }
 
-    fn vol_and_orders_at_price(&self, price: &Price) -> (Vol, OrderCount) {
+    fn vol_and_orders_at_price(&self, price: Price) -> (Vol, OrderCount) {
         self.0.vol_and_orders_at_price(price)
     }
 }
@@ -462,8 +463,8 @@ mod tests {
         side.insert_order(get_ask_key(1, 100), 2, 20);
         side.insert_order(get_ask_key(1, 101), 3, 40);
 
-        assert!(side.vol_and_orders_at_price(&100) == (30, 2));
-        assert!(side.vol_and_orders_at_price(&101) == (40, 1));
-        assert!(side.vol_and_orders_at_price(&102) == (0, 0));
+        assert!(side.vol_and_orders_at_price(100) == (30, 2));
+        assert!(side.vol_and_orders_at_price(101) == (40, 1));
+        assert!(side.vol_and_orders_at_price(102) == (0, 0));
     }
 }

--- a/crates/order_book/src/types.rs
+++ b/crates/order_book/src/types.rs
@@ -213,3 +213,24 @@ pub enum Event {
         new_vol: Option<Vol>,
     },
 }
+
+/// Level 1 market data
+pub struct Level1Data {
+    pub bid_price: Price,
+    pub ask_price: Price,
+    pub bid_vol: Vol,
+    pub ask_vol: Vol,
+    pub bid_touch_vol: Vol,
+    pub ask_touch_vol: Vol,
+    pub bid_touch_orders: OrderCount,
+    pub ask_touch_orders: OrderCount,
+}
+
+pub struct Level2Data<const N: usize> {
+    pub bid_price: Price,
+    pub ask_price: Price,
+    pub bid_vol: Vol,
+    pub ask_vol: Vol,
+    pub bid_price_levels: [(Vol, OrderCount); N],
+    pub ask_price_levels: [(Vol, OrderCount); N],
+}

--- a/crates/step_sim/examples/random_agents/main.rs
+++ b/crates/step_sim/examples/random_agents/main.rs
@@ -9,7 +9,7 @@ struct SimAgents {
 }
 
 pub fn main() {
-    let mut env = Env::new(0, 1_000_000, true);
+    let mut env = Env::new(0, 1, 1_000_000, true);
 
     let mut agents = SimAgents {
         a: RandomAgents::new(50, (40, 60), (10, 20), 2, 0.8),

--- a/crates/step_sim/src/agents/common.rs
+++ b/crates/step_sim/src/agents/common.rs
@@ -226,13 +226,13 @@ mod test {
 
         let buy_order = env.get_orders()[0];
 
-        matches!(buy_order.side, Side::Bid);
+        assert!(matches!(buy_order.side, Side::Bid));
         assert!(buy_order.price % 5 == 0);
         assert!(buy_order.price <= 200);
 
         let sell_order = env.get_orders()[1];
 
-        matches!(sell_order.side, Side::Ask);
+        assert!(matches!(sell_order.side, Side::Ask));
         assert!(sell_order.price % 5 == 0);
         assert!(sell_order.price >= 200);
     }

--- a/crates/step_sim/src/agents/common.rs
+++ b/crates/step_sim/src/agents/common.rs
@@ -5,7 +5,7 @@ use rand::{Rng, RngCore};
 use rand_distr::Distribution;
 
 use crate::types::{OrderId, Price, Side, Status, TraderId, Vol};
-use crate::Env;
+use crate::{Env, OrderError};
 
 /// Round a price up to the nearest tick and cast to a [Price]
 ///
@@ -99,7 +99,7 @@ pub fn place_buy_limit_order<R: RngCore, D: Distribution<f64>>(
     tick_size: f64,
     trade_vol: Vol,
     trader_id: TraderId,
-) -> OrderId {
+) -> Result<OrderId, OrderError> {
     let dist = price_dist.sample(rng).abs();
     let price = mid_price - dist;
     let price = round_price_down(price, tick_size);
@@ -132,7 +132,7 @@ pub fn place_sell_limit_order<R: RngCore, D: Distribution<f64>>(
     tick_size: f64,
     trade_vol: Vol,
     trader_id: TraderId,
-) -> OrderId {
+) -> Result<OrderId, OrderError> {
     let dist = price_dist.sample(rng).abs();
     let price = mid_price + dist;
     let price = round_price_up(price, tick_size);
@@ -195,7 +195,7 @@ mod test {
         let ids: Vec<OrderId> = (0..10)
             .into_iter()
             .map(|x| {
-                env.place_order(Side::Bid, 100, 0, Some(50));
+                env.place_order(Side::Bid, 100, 0, Some(50)).unwrap();
                 x
             })
             .collect();

--- a/crates/step_sim/src/agents/common.rs
+++ b/crates/step_sim/src/agents/common.rs
@@ -189,7 +189,7 @@ mod test {
 
     #[test]
     fn test_cancel_orders() {
-        let mut env = Env::new(0, 1_000_000, true);
+        let mut env = Env::new(0, 1, 1_000_000, true);
         let mut rng = Xoroshiro128StarStar::seed_from_u64(101);
 
         let ids: Vec<OrderId> = (0..10)
@@ -213,7 +213,7 @@ mod test {
 
     #[test]
     fn test_placing_orders() {
-        let mut env = Env::new(0, 1_000_000, true);
+        let mut env = Env::new(0, 1, 1_000_000, true);
         let mut rng = Xoroshiro128StarStar::seed_from_u64(101);
         let price_dist = Uniform::<f64>::new(-100.0, 100.0);
         let mid_price: f64 = 200.0;

--- a/crates/step_sim/src/agents/mod.rs
+++ b/crates/step_sim/src/agents/mod.rs
@@ -151,7 +151,8 @@ mod tests {
 
     impl Agent for TestAgent {
         fn update<R: RngCore>(&mut self, env: &mut Env, _rng: &mut R) {
-            env.place_order(self.side, 10, 101, Some(self.price));
+            env.place_order(self.side, 10, 101, Some(self.price))
+                .unwrap();
         }
     }
 

--- a/crates/step_sim/src/agents/mod.rs
+++ b/crates/step_sim/src/agents/mod.rs
@@ -163,7 +163,7 @@ mod tests {
             pub b: TestAgent,
         }
 
-        let mut env = Env::new(0, 1000, true);
+        let mut env = Env::new(0, 1, 1000, true);
         let mut rng = Xoroshiro128StarStar::seed_from_u64(101);
 
         let mut test_agents = TestAgents {

--- a/crates/step_sim/src/agents/momentum_agent.rs
+++ b/crates/step_sim/src/agents/momentum_agent.rs
@@ -78,7 +78,7 @@ pub struct MomentumParams {
 ///     pub a: MomentumAgent,
 /// }
 ///
-/// let mut env = Env::new(0, 1_000_000, true);
+/// let mut env = Env::new(0, 1, 1_000_000, true);
 ///
 /// let params = MomentumParams {
 ///     tick_size: 2,
@@ -209,7 +209,7 @@ mod tests {
 
     #[test]
     fn test_init_and_no_order() {
-        let mut env = Env::new(0, 1_000_000, true);
+        let mut env = Env::new(0, 1, 1_000_000, true);
         let mut rng = Xoroshiro128StarStar::seed_from_u64(101);
 
         env.place_order(Side::Bid, 100, 0, Some(1000));

--- a/crates/step_sim/src/agents/momentum_agent.rs
+++ b/crates/step_sim/src/agents/momentum_agent.rs
@@ -168,7 +168,8 @@ impl Agent for MomentumAgent {
                         self.tick_size,
                         self.params.trade_vol,
                         *trader_id,
-                    );
+                    )
+                    .unwrap();
                     live_orders.push(order_id);
                 } else if m < 0.0 {
                     let order_id = common::place_sell_limit_order(
@@ -179,16 +180,19 @@ impl Agent for MomentumAgent {
                         self.tick_size,
                         self.params.trade_vol,
                         *trader_id,
-                    );
+                    )
+                    .unwrap();
                     live_orders.push(order_id);
                 }
             }
 
             if rng.gen::<f64>() < p_market {
                 if m > 0.0 {
-                    env.place_order(Side::Bid, self.params.trade_vol, *trader_id, None);
+                    env.place_order(Side::Bid, self.params.trade_vol, *trader_id, None)
+                        .unwrap();
                 } else if m < 0.0 {
-                    env.place_order(Side::Ask, self.params.trade_vol, *trader_id, None);
+                    env.place_order(Side::Ask, self.params.trade_vol, *trader_id, None)
+                        .unwrap();
                 }
             }
         }
@@ -212,8 +216,8 @@ mod tests {
         let mut env = Env::new(0, 1, 1_000_000, true);
         let mut rng = Xoroshiro128StarStar::seed_from_u64(101);
 
-        env.place_order(Side::Bid, 100, 0, Some(1000));
-        env.place_order(Side::Ask, 100, 0, Some(1020));
+        env.place_order(Side::Bid, 100, 0, Some(1000)).unwrap();
+        env.place_order(Side::Ask, 100, 0, Some(1020)).unwrap();
         env.step(&mut rng);
 
         let params = MomentumParams {

--- a/crates/step_sim/src/agents/noise_agent.rs
+++ b/crates/step_sim/src/agents/noise_agent.rs
@@ -43,7 +43,7 @@ pub struct NoiseAgentParams {
 ///     pub a: NoiseAgent,
 /// }
 ///
-/// let mut env = Env::new(0, 1_000_000, true);
+/// let mut env = Env::new(0, 1, 1_000_000, true);
 ///
 /// let params = NoiseAgentParams{
 ///     tick_size: 2,
@@ -187,7 +187,7 @@ mod tests {
 
     #[test]
     fn test_place_and_cancel_limit_orders() {
-        let mut env = Env::new(0, 1_000_000, true);
+        let mut env = Env::new(0, 1, 1_000_000, true);
         let mut rng = Xoroshiro128StarStar::seed_from_u64(101);
 
         let params = NoiseAgentParams {

--- a/crates/step_sim/src/agents/noise_agent.rs
+++ b/crates/step_sim/src/agents/noise_agent.rs
@@ -133,7 +133,8 @@ impl Agent for NoiseAgent {
                         self.tick_size,
                         self.params.trade_vol,
                         *trader_id,
-                    ),
+                    )
+                    .unwrap(),
                     false => common::place_sell_limit_order(
                         env,
                         rng,
@@ -142,7 +143,8 @@ impl Agent for NoiseAgent {
                         self.tick_size,
                         self.params.trade_vol,
                         *trader_id,
-                    ),
+                    )
+                    .unwrap(),
                 };
                 live_orders.push(order_id);
             }
@@ -150,8 +152,12 @@ impl Agent for NoiseAgent {
             if rng.gen::<f32>() < self.params.p_market {
                 let side = rng.gen_bool(0.5);
                 match side {
-                    true => env.place_order(Side::Bid, self.params.trade_vol, *trader_id, None),
-                    false => env.place_order(Side::Ask, self.params.trade_vol, *trader_id, None),
+                    true => env
+                        .place_order(Side::Bid, self.params.trade_vol, *trader_id, None)
+                        .unwrap(),
+                    false => env
+                        .place_order(Side::Ask, self.params.trade_vol, *trader_id, None)
+                        .unwrap(),
                 };
             }
         }

--- a/crates/step_sim/src/agents/random_agent.rs
+++ b/crates/step_sim/src/agents/random_agent.rs
@@ -90,12 +90,15 @@ impl Agent for RandomAgents {
                             let side = [Side::Ask, Side::Bid].choose(rng).unwrap();
                             let tick = rng.gen_range(self.tick_range.0..self.tick_range.1);
                             let vol = rng.gen_range(self.vol_range.0..self.vol_range.1);
-                            Some(env.place_order(
-                                *side,
-                                vol,
-                                TraderId::try_from(n).unwrap(),
-                                Some(tick * self.tick_size),
-                            ))
+                            Some(
+                                env.place_order(
+                                    *side,
+                                    vol,
+                                    TraderId::try_from(n).unwrap(),
+                                    Some(tick * self.tick_size),
+                                )
+                                .unwrap(),
+                            )
                         }
                     }
                     false => *i,

--- a/crates/step_sim/src/agents/random_agent.rs
+++ b/crates/step_sim/src/agents/random_agent.rs
@@ -141,20 +141,23 @@ mod tests {
 
         agents.update(&mut env, &mut rng);
         assert!(env.get_transactions().len() == 1);
-        matches!(env.get_transactions()[0], Event::New { .. });
+        assert!(matches!(env.get_transactions()[0], Event::New { .. }));
         assert!(agents.orders == vec![Some(0)]);
 
         env.step(&mut rng);
 
         agents.update(&mut env, &mut rng);
         assert!(env.get_transactions().len() == 1);
-        matches!(env.get_transactions()[0], Event::Cancellation { .. });
+        assert!(matches!(
+            env.get_transactions()[0],
+            Event::Cancellation { .. }
+        ));
 
         env.step(&mut rng);
 
         agents.update(&mut env, &mut rng);
         assert!(env.get_transactions().len() == 1);
-        matches!(env.get_transactions()[0], Event::New { .. });
+        assert!(matches!(env.get_transactions()[0], Event::New { .. }));
         assert!(agents.orders == vec![Some(1)]);
     }
 }

--- a/crates/step_sim/src/agents/random_agent.rs
+++ b/crates/step_sim/src/agents/random_agent.rs
@@ -38,7 +38,7 @@ use rand::RngCore;
 ///     pub a: RandomAgents,
 /// }
 ///
-/// let mut env = Env::new(0, 1_000_000, true);
+/// let mut env = Env::new(0, 1, 1_000_000, true);
 ///
 /// let mut agents = SimAgents {
 ///     a: RandomAgents::new(10, (40, 60), (10, 20), 2, 0.8),
@@ -116,7 +116,7 @@ mod tests {
 
     #[test]
     fn test_activity_rate() {
-        let mut env = Env::new(0, 1000, true);
+        let mut env = Env::new(0, 1, 1000, true);
         let mut rng = Xoroshiro128StarStar::seed_from_u64(101);
 
         let mut agents = RandomAgents::new(2, (10, 20), (20, 30), 1, 0.0);
@@ -131,7 +131,7 @@ mod tests {
 
     #[test]
     fn test_order_place_then_cancel() {
-        let mut env = Env::new(0, 1000, true);
+        let mut env = Env::new(0, 1, 1000, true);
         let mut rng = Xoroshiro128StarStar::seed_from_u64(101);
 
         let mut agents = RandomAgents::new(1, (10, 20), (20, 30), 1, 1.0);

--- a/crates/step_sim/src/env.rs
+++ b/crates/step_sim/src/env.rs
@@ -28,7 +28,7 @@ use std::mem;
 /// use rand_xoshiro::Xoroshiro128StarStar;
 /// use rand_xoshiro::rand_core::SeedableRng;
 ///
-/// let mut env = bourse_de::Env::new(0, 1_000, true);
+/// let mut env = bourse_de::Env::new(0, 1, 1_000, true);
 /// let mut rng = Xoroshiro128StarStar::seed_from_u64(101);
 ///
 /// // Submit a new order instruction
@@ -71,10 +71,10 @@ impl Env {
     /// - `trading` - Flag if `true` orders will be matched,
     ///   otherwise no trades will take place
     ///
-    pub fn new(start_time: Nanos, step_size: Nanos, trading: bool) -> Self {
+    pub fn new(start_time: Nanos, tick_size: Price, step_size: Nanos, trading: bool) -> Self {
         Self {
             step_size,
-            order_book: OrderBook::new(start_time, trading),
+            order_book: OrderBook::new(start_time, tick_size, trading),
             prices: (Vec::new(), Vec::new()),
             volumes: (Vec::new(), Vec::new()),
             touch_order_counts: (Vec::new(), Vec::new()),
@@ -296,7 +296,7 @@ mod tests {
     #[test]
     fn test_env() {
         let step_size: Nanos = 1000;
-        let mut env = Env::new(0, step_size, true);
+        let mut env = Env::new(0, 1, step_size, true);
         let mut rng = Rng::seed_from_u64(101);
 
         env.place_order(Side::Bid, 10, 101, Some(10));

--- a/crates/step_sim/src/env.rs
+++ b/crates/step_sim/src/env.rs
@@ -4,13 +4,61 @@
 //! functionality to process instructions
 //! submitted by agents and to track market data
 //!
-use bourse_book::types::{
-    Event, Nanos, Order, OrderCount, OrderId, Price, Side, Status, Trade, TraderId, Vol,
+use crate::types::{
+    Event, Level2Data, Nanos, Order, OrderCount, OrderId, Price, Side, Status, Trade, TraderId, Vol,
 };
 use bourse_book::{OrderBook, OrderError};
 use rand::seq::SliceRandom;
 use rand::RngCore;
-use std::mem;
+use std::{array, mem};
+
+/// Market data history recording
+///
+/// History of level 2 data over the course of
+/// the existence of this environment.
+pub struct Level2DataRecords<const N: usize> {
+    /// Touch price histories
+    prices: (Vec<Price>, Vec<Price>),
+    /// Bid-ask volume histories
+    volumes: (Vec<Vol>, Vec<Vol>),
+    /// Volumes at price levels
+    volumes_at_levels: ([Vec<Vol>; N], [Vec<Vol>; N]),
+    /// numbers of orders at price levels
+    orders_at_levels: ([Vec<OrderCount>; N], [Vec<OrderCount>; N]),
+}
+
+impl<const N: usize> Level2DataRecords<N> {
+    /// Initialise an empty set of records
+    fn new() -> Self {
+        Self {
+            prices: (Vec::new(), Vec::new()),
+            volumes: (Vec::new(), Vec::new()),
+            volumes_at_levels: (
+                array::from_fn(|_| Vec::new()),
+                array::from_fn(|_| Vec::new()),
+            ),
+            orders_at_levels: (
+                array::from_fn(|_| Vec::new()),
+                array::from_fn(|_| Vec::new()),
+            ),
+        }
+    }
+
+    /// Append a record to the history
+    fn append_record(&mut self, record: &Level2Data<N>) {
+        self.prices.0.push(record.bid_price);
+        self.prices.1.push(record.ask_price);
+        self.volumes.0.push(record.bid_vol);
+        self.volumes.1.push(record.ask_vol);
+        for i in 0..N {
+            self.volumes_at_levels.0[i].push(record.bid_price_levels[i].0);
+            self.orders_at_levels.0[i].push(record.bid_price_levels[i].1);
+
+            self.volumes_at_levels.1[i].push(record.ask_price_levels[i].0);
+            self.orders_at_levels.1[i].push(record.ask_price_levels[i].1);
+        }
+    }
+}
 
 /// Discrete event simulation environment
 ///
@@ -24,11 +72,11 @@ use std::mem;
 ///
 /// ```
 /// use bourse_de;
-/// use bourse_de::types;
+/// use bourse_de::{types, Env};
 /// use rand_xoshiro::Xoroshiro128StarStar;
 /// use rand_xoshiro::rand_core::SeedableRng;
 ///
-/// let mut env = bourse_de::Env::new(0, 1, 1_000, true);
+/// let mut env: Env = Env::new(0, 1, 1_000, true);
 /// let mut rng = Xoroshiro128StarStar::seed_from_u64(101);
 ///
 /// // Submit a new order instruction
@@ -42,26 +90,22 @@ use std::mem;
 /// // Update the state of the market
 /// env.step(&mut rng)
 /// ```
-pub struct Env {
+pub struct Env<const N: usize = 10> {
     /// Time-length of each simulation step
     step_size: Nanos,
     /// Simulated order book
-    order_book: OrderBook,
-    /// Bid-ask price history
-    prices: (Vec<Price>, Vec<Price>),
-    /// Bid-ask volume histories
-    volumes: (Vec<Vol>, Vec<Vol>),
-    /// Number of touch order histories
-    touch_order_counts: (Vec<OrderCount>, Vec<OrderCount>),
-    /// Bid-ask touch volume histories
-    touch_volumes: (Vec<Vol>, Vec<Vol>),
+    order_book: OrderBook<N>,
     /// Per step trade volume histories
     trade_vols: Vec<Vol>,
     /// Transaction queue
     transactions: Vec<Event>,
+    /// Current level 2 market data
+    level_2_data: Level2Data<N>,
+    /// Level 2 data history
+    level_2_data_records: Level2DataRecords<N>,
 }
 
-impl Env {
+impl<const N: usize> Env<N> {
     /// Initialise an empty environment
     ///
     /// # Arguments
@@ -72,15 +116,15 @@ impl Env {
     ///   otherwise no trades will take place
     ///
     pub fn new(start_time: Nanos, tick_size: Price, step_size: Nanos, trading: bool) -> Self {
+        let order_book = OrderBook::new(start_time, tick_size, trading);
+        let level_2_data = order_book.level_2_data();
         Self {
             step_size,
-            order_book: OrderBook::new(start_time, tick_size, trading),
-            prices: (Vec::new(), Vec::new()),
-            volumes: (Vec::new(), Vec::new()),
-            touch_order_counts: (Vec::new(), Vec::new()),
-            touch_volumes: (Vec::new(), Vec::new()),
+            order_book,
             trade_vols: Vec::new(),
             transactions: Vec::new(),
+            level_2_data,
+            level_2_data_records: Level2DataRecords::new(),
         }
     }
 
@@ -118,20 +162,9 @@ impl Env {
 
         self.order_book.set_time(start_time + self.step_size);
 
-        let bid_ask = self.order_book.bid_ask();
-        self.prices.0.push(bid_ask.0);
-        self.prices.1.push(bid_ask.1);
-        self.volumes.0.push(self.order_book.bid_vol());
-        self.volumes.1.push(self.order_book.ask_vol());
-
-        let (bid_touch_vol, bid_touch_order_count) = self.order_book.bid_best_vol_and_orders();
-        self.touch_volumes.0.push(bid_touch_vol);
-        self.touch_order_counts.0.push(bid_touch_order_count);
-
-        let (ask_touch_vol, ask_touch_order_count) = self.order_book.ask_best_vol_and_orders();
-        self.touch_volumes.1.push(ask_touch_vol);
-        self.touch_order_counts.1.push(ask_touch_order_count);
-
+        // Update data records
+        self.level_2_data = self.order_book.level_2_data();
+        self.level_2_data_records.append_record(&self.level_2_data);
         self.trade_vols.push(self.order_book.get_trade_vol());
     }
 
@@ -221,22 +254,28 @@ impl Env {
 
     /// Get reference to bid-ask price histories
     pub fn get_prices(&self) -> &(Vec<Price>, Vec<Price>) {
-        &self.prices
+        &self.level_2_data_records.prices
     }
 
     /// Get bid-ask volume histories
     pub fn get_volumes(&self) -> &(Vec<Vol>, Vec<Vol>) {
-        &self.volumes
+        &self.level_2_data_records.volumes
     }
 
     /// Get bid-ask touch histories
-    pub fn get_touch_volumes(&self) -> &(Vec<Vol>, Vec<Vol>) {
-        &self.touch_volumes
+    pub fn get_touch_volumes(&self) -> (&Vec<Vol>, &Vec<Vol>) {
+        (
+            &self.level_2_data_records.volumes_at_levels.0[0],
+            &self.level_2_data_records.volumes_at_levels.1[0],
+        )
     }
 
     /// Get bid-ask order_count histories
-    pub fn get_touch_order_counts(&self) -> &(Vec<OrderCount>, Vec<OrderCount>) {
-        &self.touch_order_counts
+    pub fn get_touch_order_counts(&self) -> (&Vec<OrderCount>, &Vec<OrderCount>) {
+        (
+            &self.level_2_data_records.orders_at_levels.0[0],
+            &self.level_2_data_records.orders_at_levels.1[0],
+        )
     }
 
     /// Get per step trade volume histories
@@ -250,8 +289,13 @@ impl Env {
     }
 
     /// Get reference to the underlying orderbook
-    pub fn get_orderbook(&self) -> &OrderBook {
+    pub fn get_orderbook(&self) -> &OrderBook<N> {
         &self.order_book
+    }
+
+    /// Get level 2 data history
+    pub fn get_level_2_data_history(&self) -> &Level2DataRecords<N> {
+        &self.level_2_data_records
     }
 
     /// Get reference to trade data
@@ -296,7 +340,7 @@ mod tests {
     #[test]
     fn test_env() {
         let step_size: Nanos = 1000;
-        let mut env = Env::new(0, 1, step_size, true);
+        let mut env: Env = Env::new(0, 1, step_size, true);
         let mut rng = Rng::seed_from_u64(101);
 
         env.place_order(Side::Bid, 10, 101, Some(10)).unwrap();
@@ -341,12 +385,12 @@ mod tests {
         assert!(volumes.1 == vec![20, 40, 10]);
 
         let touch_volumes = env.get_touch_volumes();
-        assert!(touch_volumes.0 == vec![10, 10, 10]);
-        assert!(touch_volumes.1 == vec![20, 20, 10]);
+        assert!(*touch_volumes.0 == vec![10, 10, 10]);
+        assert!(*touch_volumes.1 == vec![20, 20, 10]);
 
         let touch_order_counts = env.get_touch_order_counts();
-        assert!(touch_order_counts.0 == vec![1, 1, 1]);
-        assert!(touch_order_counts.1 == vec![1, 1, 1]);
+        assert!(*touch_order_counts.0 == vec![1, 1, 1]);
+        assert!(*touch_order_counts.1 == vec![1, 1, 1]);
 
         let trade_vols = env.get_trade_vols();
         assert!(*trade_vols == vec![0, 0, 30]);

--- a/crates/step_sim/src/env.rs
+++ b/crates/step_sim/src/env.rs
@@ -18,13 +18,13 @@ use std::{array, mem};
 /// the existence of this environment.
 pub struct Level2DataRecords<const N: usize> {
     /// Touch price histories
-    prices: (Vec<Price>, Vec<Price>),
+    pub prices: (Vec<Price>, Vec<Price>),
     /// Bid-ask volume histories
-    volumes: (Vec<Vol>, Vec<Vol>),
+    pub volumes: (Vec<Vol>, Vec<Vol>),
     /// Volumes at price levels
-    volumes_at_levels: ([Vec<Vol>; N], [Vec<Vol>; N]),
+    pub volumes_at_levels: ([Vec<Vol>; N], [Vec<Vol>; N]),
     /// numbers of orders at price levels
-    orders_at_levels: ([Vec<OrderCount>; N], [Vec<OrderCount>; N]),
+    pub orders_at_levels: ([Vec<OrderCount>; N], [Vec<OrderCount>; N]),
 }
 
 impl<const N: usize> Level2DataRecords<N> {
@@ -106,6 +106,8 @@ pub struct Env<const N: usize = 10> {
 }
 
 impl<const N: usize> Env<N> {
+    pub const N_LEVELS: usize = N;
+
     /// Initialise an empty environment
     ///
     /// # Arguments
@@ -173,7 +175,7 @@ impl<const N: usize> Env<N> {
         self.order_book.enable_trading();
     }
 
-    /// Disable tradeing
+    /// Disable trading
     pub fn disable_trading(&mut self) {
         self.order_book.disable_trading();
     }
@@ -321,6 +323,11 @@ impl<const N: usize> Env<N> {
     ///
     pub fn order_status(&self, order_id: OrderId) -> Status {
         self.order_book.order(order_id).status
+    }
+
+    /// Reference to current level-2 market data
+    pub fn level_2_data(&self) -> &Level2Data<N> {
+        &self.level_2_data
     }
 
     #[cfg(test)]

--- a/crates/step_sim/src/lib.rs
+++ b/crates/step_sim/src/lib.rs
@@ -49,7 +49,8 @@
 //!     fn update<R: RngCore>(
 //!         &mut self, env: &mut Env, rng: &mut R
 //!     ) {
-//!         let (bid, ask) = env.get_orderbook().bid_ask();
+//!         let bid = env.level_2_data().bid_price;
+//!         let ask = env.level_2_data().ask_price;
 //!         let mid = (ask - bid) / 2;
 //!         let mid_price = bid + mid;
 //!         for _ in (0..self.n_agents) {

--- a/crates/step_sim/src/lib.rs
+++ b/crates/step_sim/src/lib.rs
@@ -69,7 +69,7 @@
 //! }
 //!
 //! // Initialise the environment and agents
-//! let mut env = Env::new(0, 1_000_000, true);
+//! let mut env = Env::new(0, 1, 1_000_000, true);
 //! let mut agents = Agents{offset: 6, vol: 50, n_agents: 10};
 //!
 //! // Run the simulation
@@ -116,7 +116,7 @@
 //!     pub b: AgentTypeB,
 //! }
 //!
-//! let mut env = bourse_de::Env::new(0, 1_000_000, true);
+//! let mut env = bourse_de::Env::new(0, 1, 1_000_000, true);
 //! let mut agents = SimAgents{a: AgentTypeA{}, b: AgentTypeB{}};
 //!
 //! sim_runner(&mut env, &mut agents, 101, 50);

--- a/crates/step_sim/src/lib.rs
+++ b/crates/step_sim/src/lib.rs
@@ -134,6 +134,6 @@ pub mod agents;
 mod env;
 mod runner;
 
-pub use bourse_book::types;
+pub use bourse_book::{types, OrderError};
 pub use env::Env;
 pub use runner::sim_runner;

--- a/crates/step_sim/src/runner.rs
+++ b/crates/step_sim/src/runner.rs
@@ -27,7 +27,7 @@ use rand_xoshiro::Xoroshiro128StarStar;
 ///     ) {}
 /// }
 ///
-/// let mut env = bourse_de::Env::new(0, 1_000, true);
+/// let mut env = bourse_de::Env::new(0, 1, 1_000, true);
 /// let mut agents = Agents{};
 ///
 /// // Run for 100 steps from seed 101

--- a/docs/source/pages/example.rst
+++ b/docs/source/pages/example.rst
@@ -49,7 +49,7 @@ We then initialise an environment and set of agents
    n_steps = 50
 
    agents = [RandomAgent(i, (10, 100)) for i in range(50)]
-   env = bourse.core.StepEnv(seed, 0, 100_000)
+   env = bourse.core.StepEnv(seed, 0, 1, 100_000)
 
 We can then use :py:meth:`bourse.step_sim.run` to run the
 simulation

--- a/docs/source/pages/usage.rst
+++ b/docs/source/pages/usage.rst
@@ -22,7 +22,7 @@ An orderbook is initialised with a start time
 
    import bourse
 
-   book = bourse.core.OrderBook(0)
+   book = bourse.core.OrderBook(0, 1)
 
 The state of the orderbook an then be directly
 updated, for example placing a limit bid order
@@ -86,7 +86,7 @@ long in time each simulated step is)
 
    seed = 101
    step_size = 100_000
-   env = bourse.core.StepEnv(seed, 0, step_size)
+   env = bourse.core.StepEnv(seed, 0, 1, step_size)
 
 The state of the simulation is updated in discrete
 steps, with transactions submitted to a queue to
@@ -109,6 +109,14 @@ step, for example bid-ask prices can be retrieved using
 .. testcode:: sim_usage
 
    bid_prices, ask_prices = env.get_prices()
+
+the full level 2 data (price and volumes along with volumes
+and number of orders at top 10 levels) records can be
+retrieved with
+
+.. testcode:: sim_usage
+
+   level_2_data = env.get_market_data()
 
 See :py:class:`bourse.core.StepEnv` for full details
 of the environment API.

--- a/examples/random_trades.py
+++ b/examples/random_trades.py
@@ -5,7 +5,7 @@ from bourse.step_sim.agents import RandomAgent
 def run(seed: int, n_steps: int, n_agents: int):
 
     agents = [RandomAgent(i, 0.5, (10, 100), (20, 50), 2) for i in range(n_agents)]
-    env = bourse.core.StepEnv(seed, 0, 100_000)
+    env = bourse.core.StepEnv(seed, 0, 1, 100_000)
 
     market_data = bourse.step_sim.run(env, agents, n_steps, seed)
 

--- a/rust/src/order_book.rs
+++ b/rust/src/order_book.rs
@@ -37,9 +37,9 @@ pub struct OrderBook(BaseOrderBook);
 #[pymethods]
 impl OrderBook {
     #[new]
-    #[pyo3(signature = (start_time, trading=true))]
-    pub fn new(start_time: Nanos, trading: bool) -> PyResult<Self> {
-        let inner = BaseOrderBook::new(start_time, trading);
+    #[pyo3(signature = (start_time, tick_size, trading=true))]
+    pub fn new(start_time: Nanos, tick_size: Price, trading: bool) -> PyResult<Self> {
+        let inner = BaseOrderBook::new(start_time, tick_size, trading);
         Ok(Self(inner))
     }
 

--- a/rust/src/step_sim.rs
+++ b/rust/src/step_sim.rs
@@ -1,3 +1,4 @@
+use std::array;
 use std::collections::HashMap;
 
 use super::types::{cast_order, cast_trade, status_to_int, PyOrder, PyTrade};
@@ -82,25 +83,37 @@ impl StepEnv {
     /// int: Current total ask side volume
     #[getter]
     pub fn ask_vol(&self) -> Vol {
-        self.env.get_orderbook().ask_vol()
+        self.env.level_2_data().ask_vol
     }
 
     /// int: Current ask side touch volume
     #[getter]
     pub fn best_ask_vol(&mut self) -> Vol {
-        self.env.get_orderbook().ask_best_vol()
+        self.env.level_2_data().ask_price_levels[0].0
     }
 
     /// tuple[int, int]: Current ask touch volume and order count
     #[getter]
     pub fn best_ask_vol_and_orders(&self) -> (Vol, OrderCount) {
-        self.env.get_orderbook().ask_best_vol_and_orders()
+        self.env.level_2_data().ask_price_levels[0]
     }
 
     /// int: Current total bid side volume
     #[getter]
     pub fn bid_vol(&self) -> Vol {
-        self.env.get_orderbook().bid_vol()
+        self.env.level_2_data().bid_vol
+    }
+
+    /// int: Current bid side touch volume
+    #[getter]
+    pub fn best_bid_vol(&mut self) -> Vol {
+        self.env.level_2_data().bid_price_levels[0].0
+    }
+
+    /// tuple[int, int]: Current bid touch volume and order count
+    #[getter]
+    pub fn best_bid_vol_and_orders(&self) -> (Vol, OrderCount) {
+        self.env.level_2_data().bid_price_levels[0]
     }
 
     /// int: Trade volume in the last step
@@ -109,22 +122,13 @@ impl StepEnv {
         self.env.get_orderbook().get_trade_vol()
     }
 
-    /// int: Current bid side touch volume
-    #[getter]
-    pub fn best_bid_vol(&mut self) -> Vol {
-        self.env.get_orderbook().bid_best_vol()
-    }
-
-    /// tuple[int, int]: Current bid touch volume and order count
-    #[getter]
-    pub fn best_bid_vol_and_orders(&self) -> (Vol, OrderCount) {
-        self.env.get_orderbook().bid_best_vol_and_orders()
-    }
-
     /// tuple[int, int]: Current bid-ask prices
     #[getter]
     pub fn bid_ask(&mut self) -> (Price, Price) {
-        self.env.get_orderbook().bid_ask()
+        (
+            self.env.level_2_data().bid_price,
+            self.env.level_2_data().ask_price,
+        )
     }
 
     /// order_status(order_id: int) -> int
@@ -414,44 +418,71 @@ impl StepEnv {
     ///
     /// Get simulation market data
     ///
-    /// Get a dictionary containing level 1 market data over the simulation
+    /// Get a dictionary containing level 2 market data over the simulation
     ///
     /// - Bid and ask touch prices
     /// - Bid and ask volumes
-    /// - Trade volumes at each step
+    /// - Volumes and number of orders at 10 levels from the touch
     ///
     /// Returns
     /// -------
     /// dict[str, np.ndarray]
     ///     Dictionary containing level 1 data with keys:
     ///
-    ///         - ``bid_price`` - Touch price
-    ///         - ``ask_price`` - Touch price
-    ///         - ``bid_vol`` - Total volume
-    ///         - ``ask_vol`` - Total volume
-    ///         - ``bid_touch_vol`` - Touch volume
-    ///         - ``ask_touch_vol`` - Touch volume
-    ///         - ``bid_touch_order_count`` - Number of orders at touch
-    ///         - ``ask_touch_order_count`` - Number of orders at touch
-    ///         - ``trade_vol`` - Total trade vol over a step
+    ///     - ``bid_price`` - Touch price
+    ///     - ``ask_price`` - Touch price
+    ///     - ``bid_vol`` - Total volume
+    ///     - ``ask_vol`` - Total volume
+    ///     - ``trade_vol`` - Total trade vol over a step
+    ///     - ``bid_vol_<N>`` - Volumes at 10 levels from bid touch
+    ///     - ``ask_vol_<N>`` - Volumes at 10 levels from ask touch
+    ///     - ``n_bid_<N>`` - Number of orders at 10 levels from the bid
+    ///     - ``n_ask_<N>`` - Number of orders at 10 levels from the ask
     ///
-    pub fn get_market_data<'a>(&self, py: Python<'a>) -> HashMap<&str, &'a PyArray1<u32>> {
-        let prices = self.get_prices(py);
-        let volumes = self.get_volumes(py);
+    pub fn get_market_data<'a>(&self, py: Python<'a>) -> HashMap<String, &'a PyArray1<u32>> {
+        let data = self.env.get_level_2_data_history();
         let trade_volumes = self.get_trade_volumes(py);
-        let touch_volumes = self.get_touch_volumes(py);
-        let touch_order_counts = self.get_touch_order_counts(py);
 
-        HashMap::from([
-            ("bid_price", prices.0),
-            ("ask_price", prices.1),
-            ("bid_vol", volumes.0),
-            ("ask_vol", volumes.1),
-            ("bid_touch_vol", touch_volumes.0),
-            ("ask_touch_vol", touch_volumes.1),
-            ("bid_touch_order_count", touch_order_counts.0),
-            ("ask_touch_order_count", touch_order_counts.1),
-            ("trade_vol", trade_volumes),
-        ])
+        let bid_vols: [(String, &'a PyArray1<u32>); 10] = array::from_fn(|i| {
+            (
+                format!("bid_vol_{i}"),
+                data.volumes_at_levels.0[i].to_pyarray(py),
+            )
+        });
+        let ask_vols: [(String, &'a PyArray1<u32>); 10] = array::from_fn(|i| {
+            (
+                format!("ask_vol_{i}"),
+                data.volumes_at_levels.1[i].to_pyarray(py),
+            )
+        });
+
+        let bid_orders: [(String, &'a PyArray1<u32>); 10] = array::from_fn(|i| {
+            (
+                format!("n_bid_{i}"),
+                data.orders_at_levels.0[i].to_pyarray(py),
+            )
+        });
+        let ask_orders: [(String, &'a PyArray1<u32>); 10] = array::from_fn(|i| {
+            (
+                format!("n_ask_{i}"),
+                data.orders_at_levels.1[i].to_pyarray(py),
+            )
+        });
+
+        let mut py_data = HashMap::from([
+            ("bid_price".to_string(), data.prices.0.to_pyarray(py)),
+            ("ask_price".to_string(), data.prices.1.to_pyarray(py)),
+            ("bid_vol".to_string(), data.volumes.0.to_pyarray(py)),
+            ("ask_vol".to_string(), data.volumes.1.to_pyarray(py)),
+            ("trade_vol".to_string(), trade_volumes),
+        ]);
+
+        py_data.extend(bid_vols);
+        py_data.extend(ask_vols);
+
+        py_data.extend(bid_orders);
+        py_data.extend(ask_orders);
+
+        py_data
     }
 }

--- a/rust/src/step_sim.rs
+++ b/rust/src/step_sim.rs
@@ -4,6 +4,7 @@ use super::types::{cast_order, cast_trade, status_to_int, PyOrder, PyTrade};
 use bourse_book::types::{Nanos, OrderCount, OrderId, Price, Side, TraderId, Vol};
 use bourse_de::Env as BaseEnv;
 use numpy::{PyArray1, ToPyArray};
+use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use rand_xoshiro::rand_core::SeedableRng;
 use rand_xoshiro::Xoroshiro128StarStar;
@@ -230,7 +231,11 @@ impl StepEnv {
             false => Side::Ask,
         };
         let order_id = self.env.place_order(side, vol, trader_id, price);
-        Ok(order_id)
+
+        match order_id {
+            Ok(i) => Ok(i),
+            Err(e) => Err(PyValueError::new_err(e.to_string())),
+        }
     }
 
     /// cancel_order(order_id: int)

--- a/rust/src/step_sim.rs
+++ b/rust/src/step_sim.rs
@@ -31,10 +31,11 @@ use rand_xoshiro::Xoroshiro128StarStar;
 ///
 ///    seed = 101
 ///    start_time = 0
+///    tick_size = 1
 ///    step_size = 1000
 ///
 ///    env = bourse.core.StepEnv(
-///        seed, start_time, step_size
+///        seed, start_time, tick_size, step_size
 ///    )
 ///
 ///    # Create an order to be placed in the
@@ -58,9 +59,15 @@ pub struct StepEnv {
 #[pymethods]
 impl StepEnv {
     #[new]
-    #[pyo3(signature = (seed, start_time, step_size, trading=true))]
-    pub fn new(seed: u64, start_time: Nanos, step_size: Nanos, trading: bool) -> PyResult<Self> {
-        let env = BaseEnv::new(start_time, step_size, trading);
+    #[pyo3(signature = (seed, start_time, tick_size, step_size, trading=true))]
+    pub fn new(
+        seed: u64,
+        start_time: Nanos,
+        tick_size: Price,
+        step_size: Nanos,
+        trading: bool,
+    ) -> PyResult<Self> {
+        let env = BaseEnv::new(start_time, tick_size, step_size, trading);
         let rng = Xoroshiro128StarStar::seed_from_u64(seed);
         Ok(Self { env, rng })
     }

--- a/src/bourse/step_sim/runner.py
+++ b/src/bourse/step_sim/runner.py
@@ -32,7 +32,7 @@ def run(
        import bourse
 
        agents = []
-       env = env = bourse.core.StepEnv(0, 0, 1000)
+       env = env = bourse.core.StepEnv(0, 0, 2, 1000)
 
     .. testcode:: runner_docstring
 
@@ -59,17 +59,17 @@ def run(
     Returns
     -------
     dict
-        Dictionary containing market data with keys:
+        Dictionary containing level 2 market data with keys:
 
         - ``bid_price``: Bid price at each step
         - ``ask_price``: Ask price at each step
         - ``bid_vol``: Total bid volume at each step
         - ``ask_vol``: Total ask volume at each step
-        - ``bid_touch_vol``: Bid touch volume at each step
-        - ``ask_touch_vol``: Ask touch volume at each step
-        - ``bid_touch_order_count``: Number of orders at the touch
-        - ``ask_touch_order_count``: Number of orders at the touch
         - ``trade_vol``: Trade volume each step
+        - ``bid_vol_<N>``: Bid volume at top 10 levels at each step
+        - ``ask_vol_<N>``: Ask volume at top 10 levels at each step
+        - ``n_bid_<N>``: Number of bid orders at top 10 levels at each step
+        - ``n_ask_<N>``: Number of ask orders at top 10 levels at each step
     """
 
     rng = np.random.default_rng(seed)

--- a/tests/test_order_book.py
+++ b/tests/test_order_book.py
@@ -2,7 +2,7 @@ import bourse
 
 
 def test_order_book_init():
-    ob = bourse.core.OrderBook(0)
+    ob = bourse.core.OrderBook(0, 1)
 
     assert ob.bid_ask() == (0, bourse.MAX_PRICE)
     assert ob.bid_vol() == 0
@@ -14,7 +14,7 @@ def test_order_book_init():
 
 
 def test_place_order():
-    ob = bourse.core.OrderBook(0)
+    ob = bourse.core.OrderBook(0, 1)
 
     ob.place_order(True, 10, 11, price=50)
     ob.place_order(False, 20, 12, price=60)
@@ -40,7 +40,7 @@ def test_place_order():
 
 
 def test_cancel_order():
-    ob = bourse.core.OrderBook(0)
+    ob = bourse.core.OrderBook(0, 1)
 
     id_0 = ob.place_order(True, 10, 11, price=50)
     id_1 = ob.place_order(False, 20, 12, price=60)
@@ -77,7 +77,7 @@ def test_cancel_order():
 
 
 def test_trades():
-    ob = bourse.core.OrderBook(0)
+    ob = bourse.core.OrderBook(0, 1)
 
     _ = ob.place_order(True, 10, 11, price=50)
     id_1 = ob.place_order(False, 20, 12, price=60)
@@ -125,7 +125,7 @@ def test_trades():
 
 def test_mod_order_volume():
 
-    ob = bourse.core.OrderBook(0)
+    ob = bourse.core.OrderBook(0, 1)
 
     _ = ob.place_order(True, 10, 11, price=50)
     id_1 = ob.place_order(True, 10, 11, price=55)
@@ -144,7 +144,7 @@ def test_mod_order_volume():
 
 def test_modify_order():
 
-    ob = bourse.core.OrderBook(0)
+    ob = bourse.core.OrderBook(0, 1)
 
     a = ob.place_order(True, 10, 11, price=50)
     _ = ob.place_order(False, 30, 11, price=60)
@@ -159,7 +159,7 @@ def test_modify_order():
 
 def test_get_orders():
 
-    ob = bourse.core.OrderBook(0)
+    ob = bourse.core.OrderBook(0, 1)
 
     ob.place_order(True, 10, 11, price=50)
     ob.place_order(False, 20, 12, price=60)
@@ -177,7 +177,7 @@ def test_get_orders():
 
 def test_read_write_snapshot(tmp_path):
 
-    ob = bourse.core.OrderBook(0)
+    ob = bourse.core.OrderBook(0, 1)
 
     ob.place_order(True, 10, 11, price=50)
     ob.place_order(False, 20, 12, price=60)

--- a/tests/test_order_book.py
+++ b/tests/test_order_book.py
@@ -1,3 +1,5 @@
+import pytest
+
 import bourse
 
 
@@ -37,6 +39,16 @@ def test_place_order():
     assert ob.best_ask_vol() == 20
     assert ob.best_bid_vol_and_orders() == (10, 1)
     assert ob.best_ask_vol_and_orders() == (20, 1)
+
+
+def test_incorrect_order_price():
+    ob = bourse.core.OrderBook(0, 2)
+
+    with pytest.raises(Exception):
+        ob.place_order(True, 10, 101, price=11)
+
+    with pytest.raises(Exception):
+        ob.place_order(False, 10, 101, price=11)
 
 
 def test_cancel_order():

--- a/tests/test_step_sim/test_agents.py
+++ b/tests/test_step_sim/test_agents.py
@@ -4,7 +4,7 @@ import bourse
 
 
 def test_random_agent():
-    env = bourse.core.StepEnv(101, 0, 100_000)
+    env = bourse.core.StepEnv(101, 0, 1, 100_000)
 
     agent = bourse.step_sim.agents.RandomAgent(0, 1.0, (10, 20), (20, 30), 2)
 

--- a/tests/test_step_sim/test_env.py
+++ b/tests/test_step_sim/test_env.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 
 import bourse
 
@@ -103,6 +104,15 @@ def test_step_sim_env():
     assert np.array_equal(core_data["n_ask_0"], np.array([1, 1, 1, 1]))
 
     assert np.array_equal(core_data["trade_vol"], np.array([0, 0, 150, 0]))
+
+
+def test_incorrect_price():
+    env = bourse.core.StepEnv(101, 0, 2, 100_000)
+
+    with pytest.raises(Exception):
+        env.place_order(True, 100, 101, price=21)
+    with pytest.raises(Exception):
+        env.place_order(False, 100, 101, price=21)
 
 
 def test_runner():

--- a/tests/test_step_sim/test_env.py
+++ b/tests/test_step_sim/test_env.py
@@ -80,12 +80,13 @@ def test_step_sim_env():
         "ask_price",
         "bid_vol",
         "ask_vol",
-        "bid_touch_vol",
-        "ask_touch_vol",
-        "bid_touch_order_count",
-        "ask_touch_order_count",
         "trade_vol",
     }
+
+    expected_keys.update({f"bid_vol_{i}" for i in range(10)})
+    expected_keys.update({f"ask_vol_{i}" for i in range(10)})
+    expected_keys.update({f"n_bid_{i}" for i in range(10)})
+    expected_keys.update({f"n_ask_{i}" for i in range(10)})
 
     assert set(core_data.keys()) == expected_keys
 
@@ -95,11 +96,11 @@ def test_step_sim_env():
     assert np.array_equal(core_data["bid_vol"], np.array([100, 200, 200, 200]))
     assert np.array_equal(core_data["ask_vol"], np.array([100, 200, 50, 50]))
 
-    assert np.array_equal(core_data["bid_touch_vol"], np.array([100, 100, 100, 100]))
-    assert np.array_equal(core_data["ask_touch_vol"], np.array([100, 100, 50, 50]))
+    assert np.array_equal(core_data["bid_vol_0"], np.array([100, 100, 100, 100]))
+    assert np.array_equal(core_data["ask_vol_0"], np.array([100, 100, 50, 50]))
 
-    assert np.array_equal(core_data["bid_touch_order_count"], np.array([1, 1, 1, 1]))
-    assert np.array_equal(core_data["ask_touch_order_count"], np.array([1, 1, 1, 1]))
+    assert np.array_equal(core_data["n_bid_0"], np.array([1, 1, 1, 1]))
+    assert np.array_equal(core_data["n_ask_0"], np.array([1, 1, 1, 1]))
 
     assert np.array_equal(core_data["trade_vol"], np.array([0, 0, 150, 0]))
 
@@ -129,6 +130,6 @@ def test_runner():
     assert np.array_equal(data["ask_price"], 50 - np.arange(10))
     assert np.array_equal(data["bid_vol"], 10 * np.arange(1, 11))
     assert np.array_equal(data["ask_vol"], 10 * np.arange(1, 11))
-    assert np.array_equal(data["bid_touch_vol"], 10 * np.ones(10))
-    assert np.array_equal(data["ask_touch_vol"], 10 * np.ones(10))
+    assert np.array_equal(data["bid_vol_0"], 10 * np.ones(10))
+    assert np.array_equal(data["ask_vol_0"], 10 * np.ones(10))
     assert np.array_equal(data["trade_vol"], np.zeros(10))

--- a/tests/test_step_sim/test_env.py
+++ b/tests/test_step_sim/test_env.py
@@ -5,7 +5,7 @@ import bourse
 
 def test_step_sim_env():
 
-    env = bourse.core.StepEnv(101, 0, 100_000)
+    env = bourse.core.StepEnv(101, 0, 1, 100_000)
 
     env.place_order(True, 100, 101, price=50)
     env.place_order(False, 100, 101, price=60)
@@ -120,7 +120,7 @@ def test_runner():
             env.place_order(self.side, 10, 101, price=new_price)
             self.step += 1
 
-    env = bourse.core.StepEnv(101, 0, 100_000)
+    env = bourse.core.StepEnv(101, 0, 1, 100_000)
     agents = [TestAgent(True, 10), TestAgent(False, 50)]
 
     data = bourse.step_sim.run(env, agents, 10, 101)


### PR DESCRIPTION
Track level 2 market data, i.e. price and volumes but also volumes and number of orders at each level (for a fixed number of levels from the best), also:

- Add tick-size as an order-book attribute
- Return an exception if an order is created with non tick multiple price