### PR TITLE
Multi asset Simulations

### DIFF
--- a/.github/workflows/pre_merge.yaml
+++ b/.github/workflows/pre_merge.yaml
@@ -20,10 +20,12 @@ jobs:
           run: cargo fmt --all -- --check
         - name: Clippy
           run: cargo clippy -- -Dwarnings
-        - name: Random stepped example
+        - name: Random discrete-event example
           run: cargo run --example random_agents
         - name: Order book example
           run: cargo run --example order_book
+        - name: Multi-asset example
+          run: cargo run --example multi_asset
         - name: Build docs 📚
           run: cargo doc --no-deps
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -540,9 +540,9 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.78"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2422ad645d89c99f8f3e6b88a9fdeca7fabeac836b1002371c4367c8f984aae"
+checksum = "e835ff2298f5721608eb1a980ecaee1aef2c132bf95ecc026a11b7bf3c01c02e"
 dependencies = [
  "unicode-ident",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,21 @@
 version = 3
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstyle"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -19,6 +34,12 @@ name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "bitflags"
@@ -52,6 +73,7 @@ dependencies = [
  "rand_xoshiro",
  "serde",
  "serde_json",
+ "serde_with",
 ]
 
 [[package]]
@@ -77,10 +99,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
+
+[[package]]
+name = "cc"
+version = "1.0.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2678b2e3449475e95b0aa6f9b506a28e61b3dc8996592b983695e8ebb58a8b41"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "chrono"
+version = "0.4.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a0d04d43504c61aa6c7531f1871dd0d418d91130162063b789da00fd7057a5e"
+dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
+ "num-traits",
+ "serde",
+ "windows-targets 0.52.0",
+]
 
 [[package]]
 name = "clap"
@@ -115,6 +162,57 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf0a07a401f374238ab8e2f11a104d2851bf9ce711ec69804834de8af45c7af"
 
 [[package]]
+name = "core-foundation-sys"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
+
+[[package]]
+name = "darling"
+version = "0.20.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54e36fcd13ed84ffdfda6f5be89b31287cbb80c439841fe69e04841435464391"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c2cf1c23a687a1feeb728783b993c4e1ad83d99f351801977dd809b48d0a70f"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.50",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a668eda54683121533a393014d8692171709ff57a7d61f187b6e782719f8933f"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.50",
+]
+
+[[package]]
+name = "deranged"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
+dependencies = [
+ "powerfmt",
+ "serde",
+]
+
+[[package]]
 name = "divan"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -140,6 +238,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
 name = "errno"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -148,6 +252,12 @@ dependencies = [
  "libc",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "getrandom"
@@ -161,10 +271,79 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
+
+[[package]]
 name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7ffbb5a1b541ea2561f8c41c087286cc091e21e556a4f09a8f6cbf17b69b141"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+ "serde",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.14.3",
+ "serde",
+]
 
 [[package]]
 name = "indoc"
@@ -177,6 +356,15 @@ name = "itoa"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
+
+[[package]]
+name = "js-sys"
+version = "0.3.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
+dependencies = [
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "kdam"
@@ -215,6 +403,12 @@ dependencies = [
  "autocfg",
  "scopeguard",
 ]
+
+[[package]]
+name = "log"
+version = "0.4.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 
 [[package]]
 name = "matrixmultiply"
@@ -256,6 +450,12 @@ checksum = "23c6602fda94a57c990fe0df199a035d83576b496aa29f4e634a8ac6004e68a6"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
 name = "num-integer"
@@ -325,6 +525,12 @@ name = "portable-atomic"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7170ef9988bc169ba16dd36a7fa041e5c4cbeb6a35b76d4c03daded371eae7c0"
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -546,10 +752,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_with"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee80b0e361bbf88fd2f6e242ccd19cfda072cb0faa6ae694ecee08199938569a"
+dependencies = [
+ "base64",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.2.6",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "serde_with_macros",
+ "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6561dc161a9224638a31d876ccdfefbc1df91d3f3a8342eddb35f055d48c7655"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.50",
+]
+
+[[package]]
 name = "smallvec"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
+
+[[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
@@ -590,6 +832,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef89ece63debf11bc32d1ed8d078ac870cbeb44da02afb02a9ff135ae7ca0582"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+
+[[package]]
+name = "time-macros"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -606,6 +879,69 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
+dependencies = [
+ "bumpalo",
+ "log",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.50",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.50",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
+
+[[package]]
+name = "windows-core"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
+ "windows-targets 0.52.0",
+]
 
 [[package]]
 name = "windows-sys"

--- a/crates/macros/src/lib.rs
+++ b/crates/macros/src/lib.rs
@@ -1,8 +1,6 @@
 use proc_macro::TokenStream;
 use quote::quote;
 
-extern crate self as bourse_de;
-
 /// Agent iteration macro
 ///
 /// Implements the `AgentSet` trait for a struct
@@ -12,7 +10,7 @@ extern crate self as bourse_de;
 /// which this macro automates. For example
 ///
 /// ```no_rust
-/// #[derive(Agents)]
+/// #[derive(AgentSet)]
 /// struct SimAgents {
 ///     a: AgentTypeA,
 ///     b: AgentTypeB,
@@ -37,7 +35,7 @@ extern crate self as bourse_de;
 /// }
 /// ```
 ///
-#[proc_macro_derive(Agents)]
+#[proc_macro_derive(AgentSet)]
 pub fn agents_derive(input: TokenStream) -> TokenStream {
     let ast = syn::parse(input).unwrap();
     impl_agents_macro(&ast)
@@ -69,6 +67,82 @@ fn impl_agents_macro(ast: &syn::DeriveInput) -> TokenStream {
     let output = quote! {
         impl bourse_de::agents::AgentSet for #name {
             fn update<R: rand::RngCore>(&mut self, env: &mut bourse_de::Env, rng: &mut R) {
+                #call_tokens
+            }
+        }
+    };
+
+    TokenStream::from(output)
+}
+
+/// Agent iteration macro for multi-asset market environments
+///
+/// Implements the `AgentSet` trait for a struct
+/// with fields of agent types. It's often the case
+/// we want to implement `update` function that
+/// iterates over a heterogeneous set of agents,
+/// which this macro automates. For example
+///
+/// ```no_rust
+/// #[derive(MarketAgentSet)]
+/// struct SimAgents {
+///     a: AgentTypeA,
+///     b: AgentTypeB,
+/// }
+/// ```
+///
+/// expands to
+///
+/// ```no_rust
+/// struct SimAgents {
+///     a: AgentTypeA,
+///     b: AgentTypeB,
+/// }
+///
+/// impl MarketAgentSet for SimAgents {
+///     fn update<R: RngCore, const M: usize, const N: usize>(
+///         &mut self, env: &mut MarketEnv<M, N>, rng: &mut R
+///     ) {
+///         self.a.update(env, rng);
+///         self.b.update(env, rng);
+///     }
+/// }
+/// ```
+///
+#[proc_macro_derive(MarketAgentSet)]
+pub fn market_agents_derive(input: TokenStream) -> TokenStream {
+    let ast = syn::parse(input).unwrap();
+    impl_market_agents_macro(&ast)
+}
+
+fn impl_market_agents_macro(ast: &syn::DeriveInput) -> TokenStream {
+    let name = &ast.ident;
+
+    let fields = match &ast.data {
+        syn::Data::Struct(syn::DataStruct {
+            fields: syn::Fields::Named(fields),
+            ..
+        }) => &fields.named,
+        _ => panic!("expected a struct with named fields"),
+    };
+
+    let mut call_tokens = quote!();
+
+    for field in fields {
+        let field_name = field.ident.clone();
+
+        if field_name.is_some() {
+            call_tokens.extend(quote!(
+                self.#field_name.update(env, rng);
+            ));
+        }
+    }
+
+    let output = quote! {
+        impl bourse_de::agents::MarketAgentSet for #name {
+            fn update<R: rand::RngCore, const M: usize, const N: usize>(
+                &mut self, env: &mut bourse_de::MarketEnv<M, N>, rng: &mut R
+            ) {
                 #call_tokens
             }
         }

--- a/crates/order_book/Cargo.toml
+++ b/crates/order_book/Cargo.toml
@@ -13,6 +13,7 @@ categories.workspace = true
 [dependencies]
 serde.workspace = true
 serde_json.workspace = true
+serde_with = "3.7.0"
 
 [dev-dependencies]
 rand_xoshiro.workspace = true

--- a/crates/order_book/src/lib.rs
+++ b/crates/order_book/src/lib.rs
@@ -94,8 +94,10 @@
 //!   order entry, but does not immediately place
 //!   the order on the market.
 //!
+mod market;
 mod orderbook;
 mod side;
 pub mod types;
 
+pub use market::Market;
 pub use orderbook::{OrderBook, OrderError};

--- a/crates/order_book/src/lib.rs
+++ b/crates/order_book/src/lib.rs
@@ -1,10 +1,13 @@
-//! Simulated order book
+//! Simulated order book and market
 //!
-//! Simulated order book designed for
-//! market simulations. Acts as
+//! Simulated order book and market designed
+//! for market simulations. Acts as
 //! matching engine, but also data
 //! structure tracking simulated orders
 //! and historical data.
+//!
+//! A [Market] wraps several [OrderBook]s allowing
+//! for simulations of markets of several assets.
 //!
 //! # Examples
 //!
@@ -76,6 +79,29 @@
 //! book.save_json("foo.json", true);
 //! let loaded_book: OrderBook = OrderBook::load_json("foo.json").unwrap();
 //! ```
+//!
+//! ## Initialise and Updating a Market
+//!
+//! ```
+//! use bourse_book;
+//! use bourse_book::{types, Market};
+//!
+//! // Initialise a merket with 2 assets
+//! let mut market = Market::<2>::new(0, [1, 1], true);
+//!
+//! // Place a buy order for asset 0
+//! market.create_and_place_order(
+//!     0, types::Side::Bid, 10, 0, Some(100)
+//! ).unwrap();
+//!
+//! // Place a sell order for asset 2
+//! market.create_and_place_order(
+//!     1, types::Side::Ask, 10, 0, Some(100)
+//! ).unwrap();
+//!
+//! // Get current prices across assets
+//! let prices = market.bid_asks();
+//! ````
 //!
 //! # Notes
 //!

--- a/crates/order_book/src/market.rs
+++ b/crates/order_book/src/market.rs
@@ -24,8 +24,8 @@ use crate::types::{
 ///
 /// A Market type is parametrised by 2 constants:
 ///
-/// - `N` - The number of assets
-/// - `M` - The number of price levels tracked
+/// - `ASSETS` - The number of assets
+/// - `LEVELS` - The number of price levels tracked
 ///   by each order-book (default is 10)
 ///
 /// # Examples
@@ -56,12 +56,12 @@ use crate::types::{
 ///
 #[serde_as]
 #[derive(Deserialize, Serialize)]
-pub struct Market<const N: usize, const M: usize = 10> {
-    #[serde_as(as = "[_; N]")]
-    order_books: [OrderBook<M>; N],
+pub struct Market<const ASSETS: usize, const LEVELS: usize = 10> {
+    #[serde_as(as = "[_; ASSETS]")]
+    order_books: [OrderBook<LEVELS>; ASSETS],
 }
 
-impl<const N: usize, const M: usize> Market<N, M> {
+impl<const ASSETS: usize, const LEVELS: usize> Market<ASSETS, LEVELS> {
     /// Initialise a market
     ///
     /// # Arguments
@@ -71,9 +71,11 @@ impl<const N: usize, const M: usize> Market<N, M> {
     /// - `tick_size` - Array of integer tick sizes for each asset.
     /// - `trading` - If `False` no orders will be matched.
     ///
-    pub fn new(start_time: Nanos, tick_size: [Price; N], trading: bool) -> Self {
+    pub fn new(start_time: Nanos, tick_size: [Price; ASSETS], trading: bool) -> Self {
         Self {
-            order_books: array::from_fn(|i| OrderBook::<M>::new(start_time, tick_size[i], trading)),
+            order_books: array::from_fn(|i| {
+                OrderBook::<LEVELS>::new(start_time, tick_size[i], trading)
+            }),
         }
     }
 
@@ -83,7 +85,7 @@ impl<const N: usize, const M: usize> Market<N, M> {
     ///
     /// - `asset` - Index of the asset
     ///
-    pub fn get_order_book(&self, asset: AssetIdx) -> &OrderBook<M> {
+    pub fn get_order_book(&self, asset: AssetIdx) -> &OrderBook<LEVELS> {
         &self.order_books[asset]
     }
 
@@ -93,7 +95,7 @@ impl<const N: usize, const M: usize> Market<N, M> {
     ///
     /// - `asset` - Index of the asset
     ///
-    pub fn get_order_book_mut(&mut self, asset: AssetIdx) -> &mut OrderBook<M> {
+    pub fn get_order_book_mut(&mut self, asset: AssetIdx) -> &mut OrderBook<LEVELS> {
         &mut self.order_books[asset]
     }
 
@@ -132,7 +134,7 @@ impl<const N: usize, const M: usize> Market<N, M> {
     }
 
     /// Get the current cumulative trade_volume across assets
-    pub fn get_trade_vols(&self) -> [Vol; N] {
+    pub fn get_trade_vols(&self) -> [Vol; ASSETS] {
         array::from_fn(|i| self.order_books[i].get_trade_vol())
     }
 
@@ -144,47 +146,47 @@ impl<const N: usize, const M: usize> Market<N, M> {
     }
 
     /// Get the current total ask volume for all assets
-    pub fn bid_vols(&self) -> [Vol; N] {
+    pub fn bid_vols(&self) -> [Vol; ASSETS] {
         array::from_fn(|i| self.order_books[i].bid_vol())
     }
 
     /// Get the current touch ask volume for all assets
-    pub fn bid_best_vols(&self) -> [Vol; N] {
+    pub fn bid_best_vols(&self) -> [Vol; ASSETS] {
         array::from_fn(|i| self.order_books[i].bid_best_vol())
     }
 
     /// Get the current touch ask volume and order count for all assets
-    pub fn bid_best_vol_and_orders(&self) -> [(Vol, OrderCount); N] {
+    pub fn bid_best_vol_and_orders(&self) -> [(Vol, OrderCount); ASSETS] {
         array::from_fn(|i| self.order_books[i].bid_best_vol_and_orders())
     }
 
     /// Get 2d array of orders and volumes at top levels across assets
-    pub fn bid_levels(&self) -> [[(Vol, OrderCount); M]; N] {
+    pub fn bid_levels(&self) -> [[(Vol, OrderCount); LEVELS]; ASSETS] {
         array::from_fn(|i| self.order_books[i].bid_levels())
     }
 
     /// Get the current total ask volume for all assets
-    pub fn ask_vols(&self) -> [Vol; N] {
+    pub fn ask_vols(&self) -> [Vol; ASSETS] {
         array::from_fn(|i| self.order_books[i].ask_vol())
     }
 
     /// Get the current touch ask volume for all assets
-    pub fn ask_best_vols(&self) -> [Vol; N] {
+    pub fn ask_best_vols(&self) -> [Vol; ASSETS] {
         array::from_fn(|i| self.order_books[i].ask_best_vol())
     }
 
     /// Get the current touch ask volume and order count for all assets
-    pub fn ask_best_vol_and_orders(&self) -> [(Vol, OrderCount); N] {
+    pub fn ask_best_vol_and_orders(&self) -> [(Vol, OrderCount); ASSETS] {
         array::from_fn(|i| self.order_books[i].ask_best_vol_and_orders())
     }
 
     /// Get 2d array of orders and volumes at top levels across assets
-    pub fn ask_levels(&self) -> [[(Vol, OrderCount); M]; N] {
+    pub fn ask_levels(&self) -> [[(Vol, OrderCount); LEVELS]; ASSETS] {
         array::from_fn(|i| self.order_books[i].ask_levels())
     }
 
     /// Get current bid-ask price for all assets
-    pub fn bid_asks(&self) -> [(Price, Price); N] {
+    pub fn bid_asks(&self) -> [(Price, Price); ASSETS] {
         array::from_fn(|i| self.order_books[i].bid_ask())
     }
 

--- a/crates/order_book/src/market.rs
+++ b/crates/order_book/src/market.rs
@@ -6,8 +6,8 @@ use std::{array, path::Path};
 
 use super::{OrderBook, OrderError};
 use crate::types::{
-    AssetIdx, Level2Data, MarketEvent, MarketOrderId, Nanos, Order, OrderCount, Price, Side,
-    TraderId, Vol,
+    AssetIdx, Event, Level2Data, MarketOrderId, Nanos, Order, OrderCount, Price, Side, TraderId,
+    Vol,
 };
 
 /// Multi asset market combining several [OrderBook]
@@ -331,7 +331,7 @@ impl<const ASSETS: usize, const LEVELS: usize> Market<ASSETS, LEVELS> {
         self.order_books[order_id.0].modify_order(order_id.1, new_price, new_vol)
     }
 
-    /// Process an [MarketEvent] order instruction
+    /// Process a [Event] order instruction
     ///
     /// Processes an order instruction to place, cancel
     /// or modify an order
@@ -340,11 +340,11 @@ impl<const ASSETS: usize, const LEVELS: usize> Market<ASSETS, LEVELS> {
     ///
     /// - `event` - Order instruction with asset id
     ///
-    pub fn process_event(&mut self, event: MarketEvent) {
+    pub fn process_event(&mut self, event: Event<MarketOrderId>) {
         match event {
-            MarketEvent::New { order_id } => self.place_order(order_id),
-            MarketEvent::Cancellation { order_id } => self.cancel_order(order_id),
-            MarketEvent::Modify {
+            Event::New { order_id } => self.place_order(order_id),
+            Event::Cancellation { order_id } => self.cancel_order(order_id),
+            Event::Modify {
                 order_id,
                 new_price,
                 new_vol,

--- a/crates/order_book/src/market.rs
+++ b/crates/order_book/src/market.rs
@@ -1,0 +1,454 @@
+use serde::{Deserialize, Serialize};
+use serde_with::serde_as;
+use std::{array, path::Path};
+
+use super::{OrderBook, OrderError};
+use crate::types::{
+    AssetIdx, Event, MarketEvent, MarketOrderId, Nanos, Order, OrderCount, Price, Side, TraderId,
+    Vol,
+};
+
+#[serde_as]
+#[derive(Deserialize, Serialize)]
+pub struct Market<const N: usize, const M: usize = 10> {
+    #[serde_as(as = "[_; N]")]
+    order_books: [OrderBook<M>; N],
+}
+
+impl<const N: usize, const M: usize> Market<N, M> {
+    pub fn new(start_time: Nanos, tick_size: [Price; N], trading: bool) -> Self {
+        Self {
+            order_books: array::from_fn(|i| OrderBook::<M>::new(start_time, tick_size[i], trading)),
+        }
+    }
+
+    /// Get a reference to an orderbook
+    pub fn get_order_book(&self, asset: AssetIdx) -> &OrderBook<M> {
+        &self.order_books[asset]
+    }
+
+    /// Get a mutable reference to an orderbook
+    pub fn get_order_book_mut(&mut self, asset: AssetIdx) -> &mut OrderBook<M> {
+        &mut self.order_books[asset]
+    }
+
+    /// Get the market time
+    pub fn get_time(&self) -> Nanos {
+        self.order_books[0].get_time()
+    }
+
+    /// Manually set the time of the market
+    ///
+    /// # Arguments
+    ///
+    /// - `t` - Time to set
+    ///
+    pub fn set_time(&mut self, t: Nanos) {
+        for book in self.order_books.iter_mut() {
+            book.set_time(t)
+        }
+    }
+
+    /// Enable trade execution
+    pub fn enable_trading(&mut self) {
+        for book in self.order_books.iter_mut() {
+            book.enable_trading()
+        }
+    }
+
+    /// Disable trade execution
+    ///
+    /// > **_NOTE:_** Currently there is not
+    ///   a un-crossing algorithm implemented
+    pub fn disable_trading(&mut self) {
+        for book in self.order_books.iter_mut() {
+            book.disable_trading()
+        }
+    }
+
+    /// Get the current cumulative trade_volume across assets
+    pub fn get_trade_vols(&self) -> [Vol; N] {
+        array::from_fn(|i| self.order_books[i].get_trade_vol())
+    }
+
+    /// Reset cumulative trade vol to 0
+    pub fn reset_trade_vols(&mut self) {
+        for book in self.order_books.iter_mut() {
+            book.reset_trade_vol();
+        }
+    }
+
+    /// Get the current total ask volume
+    pub fn bid_vols(&self) -> [Vol; N] {
+        array::from_fn(|i| self.order_books[i].bid_vol())
+    }
+
+    /// Get the current touch ask volume
+    pub fn bid_best_vols(&self) -> [Vol; N] {
+        array::from_fn(|i| self.order_books[i].bid_best_vol())
+    }
+
+    /// Get the current touch ask volume and order count
+    pub fn bid_best_vol_and_orders(&self) -> [(Vol, OrderCount); N] {
+        array::from_fn(|i| self.order_books[i].bid_best_vol_and_orders())
+    }
+
+    /// Get 2d array of orders and volumes at top levels across assets
+    pub fn bid_levels(&self) -> [[(Vol, OrderCount); M]; N] {
+        array::from_fn(|i| self.order_books[i].bid_levels())
+    }
+
+    /// Get the current total ask volume
+    pub fn ask_vols(&self) -> [Vol; N] {
+        array::from_fn(|i| self.order_books[i].ask_vol())
+    }
+
+    /// Get the current touch ask volume
+    pub fn ask_best_vols(&self) -> [Vol; N] {
+        array::from_fn(|i| self.order_books[i].ask_best_vol())
+    }
+
+    /// Get the current touch ask volume and order count
+    pub fn ask_best_vol_and_orders(&self) -> [(Vol, OrderCount); N] {
+        array::from_fn(|i| self.order_books[i].ask_best_vol_and_orders())
+    }
+
+    /// Get 2d array of orders and volumes at top levels across assets
+    pub fn ask_levels(&self) -> [[(Vol, OrderCount); M]; N] {
+        array::from_fn(|i| self.order_books[i].ask_levels())
+    }
+
+    /// Get current bid-ask price
+    pub fn bid_asks(&self) -> [(Price, Price); N] {
+        array::from_fn(|i| self.order_books[i].bid_ask())
+    }
+
+    /// Get a reference to the order data stored at the id
+    ///
+    /// # Arguments
+    ///
+    /// - `order_id` - Asset index and id of the order
+    ///
+    pub fn order(&self, order_id: MarketOrderId) -> &Order {
+        self.order_books[order_id.0].order(order_id.1)
+    }
+
+    /// Create a new order
+    ///
+    /// Create a new order in the order list, but
+    /// this order is not automatically placed on
+    /// the market. Returns the id of the newly
+    /// created order.
+    ///
+    /// # Arguments
+    ///
+    /// - `asset` - Id of the asset to create the order for
+    /// - `side` - Order side
+    /// - `vol` - Order volume
+    /// - `trader_id` - Id of the trader placing the order
+    /// - `price` -  Price of the order, if `None` the
+    ///   order is treated as a market order
+    ///
+    pub fn create_order(
+        &mut self,
+        asset: AssetIdx,
+        side: Side,
+        vol: Vol,
+        trader_id: TraderId,
+        price: Option<Price>,
+    ) -> Result<MarketOrderId, OrderError> {
+        let id = self.order_books[asset].create_order(side, vol, trader_id, price)?;
+        Ok((asset, id))
+    }
+
+    /// Convenience function to create and immediately place an order
+    ///
+    /// Create a new order in the order list and place it on the market.
+    /// Returns the id of the newly created order.
+    ///
+    /// # Arguments
+    ///
+    /// - `asset` - Id of the asset to create and place the order for
+    /// - `side` - Order side
+    /// - `vol` - Order volume
+    /// - `trader_id` - Id of the trader placing the order
+    /// - `price` -  Price of the order, if `None` the
+    ///   order is treated as a market order
+    ///
+    pub fn create_and_place_order(
+        &mut self,
+        asset: AssetIdx,
+        side: Side,
+        vol: Vol,
+        trader_id: TraderId,
+        price: Option<Price>,
+    ) -> Result<MarketOrderId, OrderError> {
+        let id = self.order_books[asset].create_and_place_order(side, vol, trader_id, price)?;
+        Ok((asset, id))
+    }
+
+    /// Place an order on the market
+    ///
+    /// Place an order that has been created on the market
+    ///
+    /// # Arguments
+    ///
+    /// - `order_id` - Asset index and id of the order to place
+    ///
+    pub fn place_order(&mut self, order_id: MarketOrderId) {
+        self.order_books[order_id.0].place_order(order_id.1)
+    }
+
+    /// Cancel an order
+    ///
+    /// Attempts to cancel an order, if the order is
+    /// already filled or rejected then no change is made
+    ///
+    /// # Arguments
+    ///
+    /// - `order_id` - Asset index and id of the order to place
+    ///
+    pub fn cancel_order(&mut self, order_id: MarketOrderId) {
+        self.order_books[order_id.0].cancel_order(order_id.1)
+    }
+
+    /// Modify the price and/or volume of an order
+    ///
+    /// If only the volume is *reduced*, then the order
+    /// maintains its price-time priority. Otherwise the
+    /// order is replaced. The modified order
+    /// maintains the same id.
+    ///
+    /// If the price/vol are None then the original
+    /// price/vol are kept.
+    ///
+    /// # Arguments
+    ///
+    /// - `order_id` - Asset index and id of the order to place
+    /// - `new_price` - New price of the order, `None``
+    ///   keeps the same price
+    /// - `new_vol` - New volume of the order, `None``
+    ///   keeps the same volume
+    ///
+    pub fn modify_order(
+        &mut self,
+        order_id: MarketOrderId,
+        new_price: Option<Price>,
+        new_vol: Option<Price>,
+    ) {
+        self.order_books[order_id.0].modify_order(order_id.1, new_price, new_vol)
+    }
+
+    /// Process an [MarketEvent] order instruction
+    ///
+    /// Processes an order instruction to place, cancel
+    /// or modify an order
+    ///
+    /// # Arguments
+    ///
+    /// - `event` - Order instruction with asset id
+    ///
+    pub fn process_event(&mut self, event: MarketEvent) {
+        let (asset, event) = (event.asset, event.event);
+        match event {
+            Event::New { order_id } => self.place_order((asset, order_id)),
+            Event::Cancellation { order_id } => self.cancel_order((asset, order_id)),
+            Event::Modify {
+                order_id,
+                new_price,
+                new_vol,
+            } => self.modify_order((asset, order_id), new_price, new_vol),
+        }
+    }
+
+    /// Save a snapshot of the market to JSON
+    ///
+    /// # Argument
+    ///
+    /// - `path` - Path to write snapshot JSON to
+    /// - `pretty` - If `True` JSON will be pretty printed
+    ///
+    pub fn save_json<P: AsRef<Path>>(&self, path: P, pretty: bool) -> std::io::Result<()> {
+        let file = std::fs::File::create(path)?;
+        let file = std::io::BufWriter::new(file);
+        match pretty {
+            true => serde_json::to_writer_pretty(file, self)?,
+            false => serde_json::to_writer(file, self)?,
+        }
+        Ok(())
+    }
+
+    /// Load a market from a JSON snapshot
+    ///
+    /// # Argument
+    ///
+    /// - `path` - Path to read snapshot JSON from
+    ///
+    pub fn load_json<P: AsRef<Path>>(path: P) -> std::io::Result<Self> {
+        let file = std::fs::File::open(path)?;
+        let file = std::io::BufReader::new(file);
+        let order_book: Self = serde_json::from_reader(file)?;
+        Ok(order_book)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+    use crate::types::Status;
+
+    #[test]
+    fn test_init() {
+        let market: Market<2> = Market::new(101, [1, 2], true);
+
+        assert!(market.get_time() == 101);
+        assert!(market.bid_vols() == [0, 0]);
+        assert!(market.ask_vols() == [0, 0]);
+        assert!(market.bid_best_vols() == [0, 0]);
+        assert!(market.bid_best_vol_and_orders() == [(0, 0), (0, 0)]);
+        assert!(market.bid_best_vols() == [0, 0]);
+        assert!(market.ask_best_vol_and_orders() == [(0, 0), (0, 0)]);
+        assert!(market.bid_asks() == [(0, Price::MAX), (0, Price::MAX)]);
+    }
+
+    #[test]
+    fn test_insert_order() {
+        let mut market: Market<2> = Market::new(101, [1, 2], true);
+
+        market
+            .create_and_place_order(0, Side::Ask, 10, 0, Some(100))
+            .unwrap();
+        market
+            .create_and_place_order(0, Side::Bid, 10, 0, Some(50))
+            .unwrap();
+
+        assert!(market.bid_asks() == [(50, 100), (0, Price::MAX)]);
+        assert!(market.ask_vols() == [10, 0]);
+        assert!(market.bid_vols() == [10, 0]);
+        assert!(market.bid_best_vols() == [10, 0]);
+        assert!(market.bid_best_vol_and_orders() == [(10, 1), (0, 0)]);
+        assert!(market.ask_best_vols() == [10, 0]);
+        assert!(market.ask_best_vol_and_orders() == [(10, 1), (0, 0)]);
+
+        market
+            .create_and_place_order(1, Side::Ask, 20, 0, Some(20))
+            .unwrap();
+        market
+            .create_and_place_order(1, Side::Bid, 20, 0, Some(10))
+            .unwrap();
+
+        assert!(market.bid_asks() == [(50, 100), (10, 20)]);
+        assert!(market.ask_vols() == [10, 20]);
+        assert!(market.bid_vols() == [10, 20]);
+        assert!(market.bid_best_vols() == [10, 20]);
+        assert!(market.bid_best_vol_and_orders() == [(10, 1), (20, 1)]);
+        assert!(market.ask_best_vols() == [10, 20]);
+        assert!(market.ask_best_vol_and_orders() == [(10, 1), (20, 1)]);
+
+        market
+            .create_and_place_order(0, Side::Ask, 10, 0, Some(90))
+            .unwrap();
+        market
+            .create_and_place_order(0, Side::Bid, 10, 0, Some(60))
+            .unwrap();
+
+        assert!(market.bid_asks() == [(60, 90), (10, 20)]);
+        assert!(market.ask_vols() == [20, 20]);
+        assert!(market.bid_vols() == [20, 20]);
+        assert!(market.bid_best_vols() == [10, 20]);
+        assert!(market.bid_best_vol_and_orders() == [(10, 1), (20, 1)]);
+        assert!(market.ask_best_vols() == [10, 20]);
+        assert!(market.ask_best_vol_and_orders() == [(10, 1), (20, 1)]);
+
+        market
+            .create_and_place_order(1, Side::Ask, 10, 0, Some(20))
+            .unwrap();
+        market
+            .create_and_place_order(1, Side::Bid, 10, 0, Some(12))
+            .unwrap();
+
+        assert!(market.bid_asks() == [(60, 90), (12, 20)]);
+        assert!(market.ask_vols() == [20, 30]);
+        assert!(market.bid_vols() == [20, 30]);
+        assert!(market.bid_best_vols() == [10, 10]);
+        assert!(market.bid_best_vol_and_orders() == [(10, 1), (10, 1)]);
+        assert!(market.ask_best_vols() == [10, 30]);
+        assert!(market.ask_best_vol_and_orders() == [(10, 1), (30, 2)]);
+
+        market
+            .create_and_place_order(0, Side::Ask, 10, 0, Some(110))
+            .unwrap();
+        market
+            .create_and_place_order(0, Side::Bid, 10, 0, Some(40))
+            .unwrap();
+
+        assert!(market.bid_asks() == [(60, 90), (12, 20)]);
+        assert!(market.ask_vols() == [30, 30]);
+        assert!(market.bid_vols() == [30, 30]);
+        assert!(market.bid_best_vols() == [10, 10]);
+        assert!(market.bid_best_vol_and_orders() == [(10, 1), (10, 1)]);
+        assert!(market.ask_best_vols() == [10, 30]);
+        assert!(market.ask_best_vol_and_orders() == [(10, 1), (30, 2)]);
+    }
+
+    #[test]
+    fn test_cancel_order() {
+        let mut market: Market<2> = Market::new(0, [1, 2], true);
+
+        market
+            .create_and_place_order(0, Side::Ask, 10, 0, Some(100))
+            .unwrap();
+        market
+            .create_and_place_order(0, Side::Bid, 10, 0, Some(50))
+            .unwrap();
+        market
+            .create_and_place_order(0, Side::Ask, 10, 0, Some(90))
+            .unwrap();
+        market
+            .create_and_place_order(0, Side::Bid, 10, 0, Some(60))
+            .unwrap();
+
+        market
+            .create_and_place_order(1, Side::Ask, 50, 0, Some(20))
+            .unwrap();
+        market
+            .create_and_place_order(1, Side::Bid, 50, 0, Some(10))
+            .unwrap();
+
+        assert!(market.bid_asks() == [(60, 90), (10, 20)]);
+        assert!(market.ask_vols() == [20, 50]);
+        assert!(market.bid_vols() == [20, 50]);
+        assert!(market.bid_best_vols() == [10, 50]);
+        assert!(market.ask_best_vols() == [10, 50]);
+        assert!(market.bid_best_vol_and_orders() == [(10, 1), (50, 1)]);
+        assert!(market.ask_best_vol_and_orders() == [(10, 1), (50, 1)]);
+
+        market.cancel_order((0, 0));
+        market.cancel_order((0, 3));
+
+        assert!(market.bid_asks() == [(50, 90), (10, 20)]);
+        assert!(market.ask_vols() == [10, 50]);
+        assert!(market.bid_vols() == [10, 50]);
+        assert!(market.bid_best_vols() == [10, 50]);
+        assert!(market.ask_best_vols() == [10, 50]);
+        assert!(market.bid_best_vol_and_orders() == [(10, 1), (50, 1)]);
+        assert!(market.ask_best_vol_and_orders() == [(10, 1), (50, 1)]);
+
+        market.cancel_order((0, 1));
+        market.cancel_order((0, 2));
+
+        assert!(market.bid_asks() == [(0, Price::MAX), (10, 20)]);
+        assert!(market.ask_vols() == [0, 50]);
+        assert!(market.bid_vols() == [0, 50]);
+        assert!(market.bid_best_vols() == [0, 50]);
+        assert!(market.ask_best_vols() == [0, 50]);
+        assert!(market.bid_best_vol_and_orders() == [(0, 0), (50, 1)]);
+        assert!(market.ask_best_vol_and_orders() == [(0, 0), (50, 1)]);
+
+        assert!(matches!(market.order((0, 0)).status, Status::Cancelled));
+        assert!(matches!(market.order((0, 1)).status, Status::Cancelled));
+        assert!(matches!(market.order((0, 2)).status, Status::Cancelled));
+        assert!(matches!(market.order((0, 3)).status, Status::Cancelled));
+    }
+}

--- a/crates/order_book/src/orderbook.rs
+++ b/crates/order_book/src/orderbook.rs
@@ -3,7 +3,6 @@
 //! # Examples
 //!
 //! ```
-//! use bourse_book;
 //! use bourse_book::{types, OrderBook};
 //!
 //! let mut book: OrderBook  = OrderBook::new(0, 1, true);
@@ -44,7 +43,6 @@ pub struct OrderEntry {
 /// # Examples
 ///
 /// ```
-/// use bourse_book;
 /// use bourse_book::{types, OrderBook};
 ///
 /// let mut book: OrderBook = OrderBook::new(0, 1, true);

--- a/crates/order_book/src/orderbook.rs
+++ b/crates/order_book/src/orderbook.rs
@@ -1268,7 +1268,7 @@ mod tests {
         assert!(book.bid_vol() == loaded_book.bid_vol());
 
         assert!(book.ask_best_vol_and_orders() == loaded_book.ask_best_vol_and_orders());
-        assert!(book.bid_vol() == loaded_book.bid_vol());
+        assert!(book.ask_vol() == loaded_book.ask_vol());
 
         assert!(book.current_order_id() == loaded_book.current_order_id());
 

--- a/crates/order_book/src/orderbook.rs
+++ b/crates/order_book/src/orderbook.rs
@@ -141,6 +141,8 @@ impl<const N: usize> OrderBook<N> {
 
     /// Manually set the time of the orderbook
     ///
+    /// # Arguments
+    ///
     /// - `t` - Time to set
     pub fn set_time(&mut self, t: Nanos) {
         self.t = t;

--- a/crates/order_book/src/side.rs
+++ b/crates/order_book/src/side.rs
@@ -7,7 +7,7 @@ use std::collections::BTreeMap;
 
 use super::types::{Nanos, OrderCount, OrderId, OrderKey, Price, Side, Vol};
 
-/// Common side side functionality
+/// Common order-book side functionality
 pub trait SideFunctionality {
     /// Initialise a side
     fn new() -> Self;

--- a/crates/order_book/src/types.rs
+++ b/crates/order_book/src/types.rs
@@ -248,9 +248,27 @@ pub enum Event {
     },
 }
 
-pub struct MarketEvent {
-    pub asset: AssetIdx,
-    pub event: Event,
+/// Multi-asset order/transaction instruction
+pub enum MarketEvent {
+    /// Place an order on the market
+    New {
+        /// Id of the order to place
+        order_id: MarketOrderId,
+    },
+    /// Cancel an order
+    Cancellation {
+        /// Id of the order to cancel
+        order_id: MarketOrderId,
+    },
+    /// Modify an order
+    Modify {
+        // Id of the order to modify
+        order_id: MarketOrderId,
+        /// New price of the order
+        new_price: Option<Price>,
+        /// New volume of the order
+        new_vol: Option<Vol>,
+    },
 }
 
 /// Level 1 market data

--- a/crates/order_book/src/types.rs
+++ b/crates/order_book/src/types.rs
@@ -16,6 +16,10 @@ pub type Vol = u32;
 pub type TraderId = u32;
 /// Count of orders
 pub type OrderCount = u32;
+/// Idx to an asset orderbook
+pub type AssetIdx = usize;
+/// Order Id along with asset idx
+pub type MarketOrderId = (AssetIdx, OrderId);
 
 /// Market side
 #[derive(Clone, Copy, Debug, Serialize, Deserialize)]
@@ -242,6 +246,11 @@ pub enum Event {
         /// New volume of the order
         new_vol: Option<Vol>,
     },
+}
+
+pub struct MarketEvent {
+    pub asset: AssetIdx,
+    pub event: Event,
 }
 
 /// Level 1 market data

--- a/crates/order_book/src/types.rs
+++ b/crates/order_book/src/types.rs
@@ -225,45 +225,22 @@ impl Order {
     }
 }
 
-/// Order/transaction instruction
-pub enum Event {
+/// Order transaction instruction
+pub enum Event<ID> {
     /// Place an order on the market
     New {
         /// Id of the order to place
-        order_id: OrderId,
+        order_id: ID,
     },
     /// Cancel an order
     Cancellation {
         /// Id of the order to cancel
-        order_id: OrderId,
+        order_id: ID,
     },
     /// Modify an order
     Modify {
         // Id of the order to modify
-        order_id: OrderId,
-        /// New price of the order
-        new_price: Option<Price>,
-        /// New volume of the order
-        new_vol: Option<Vol>,
-    },
-}
-
-/// Multi-asset order/transaction instruction
-pub enum MarketEvent {
-    /// Place an order on the market
-    New {
-        /// Id of the order to place
-        order_id: MarketOrderId,
-    },
-    /// Cancel an order
-    Cancellation {
-        /// Id of the order to cancel
-        order_id: MarketOrderId,
-    },
-    /// Modify an order
-    Modify {
-        // Id of the order to modify
-        order_id: MarketOrderId,
+        order_id: ID,
         /// New price of the order
         new_price: Option<Price>,
         /// New volume of the order

--- a/crates/step_sim/benches/benchmarks.rs
+++ b/crates/step_sim/benches/benchmarks.rs
@@ -1,10 +1,9 @@
 use divan::{black_box, Bencher};
 
-use bourse_de::agents::{Agent, RandomAgents};
+use bourse_de::agents::{Agent, AgentSet, RandomAgents};
 use bourse_de::{sim_runner, Env};
-use bourse_macros::Agents;
 
-#[derive(Agents)]
+#[derive(AgentSet)]
 struct SimAgents {
     pub a: RandomAgents,
     pub b: RandomAgents,

--- a/crates/step_sim/examples/multi_asset/main.rs
+++ b/crates/step_sim/examples/multi_asset/main.rs
@@ -1,0 +1,26 @@
+use bourse_de::agents::{MarketAgent, MarketAgentSet, RandomMarketAgents};
+use bourse_de::{market_sim_runner, MarketEnv};
+
+#[derive(MarketAgentSet)]
+struct Agents {
+    pub a: RandomMarketAgents,
+    pub b: RandomMarketAgents,
+    pub c: RandomMarketAgents,
+    pub d: RandomMarketAgents,
+}
+
+pub fn main() {
+    let mut env = MarketEnv::<2>::new(0, [1, 1], 1_000_000, true);
+
+    let mut agents = Agents {
+        a: RandomMarketAgents::new(0, 50, (40, 60), (10, 20), 2, 0.8),
+        b: RandomMarketAgents::new(0, 50, (10, 90), (50, 70), 2, 0.2),
+        c: RandomMarketAgents::new(1, 50, (40, 60), (10, 20), 2, 0.8),
+        d: RandomMarketAgents::new(1, 50, (10, 90), (50, 70), 2, 0.2),
+    };
+
+    market_sim_runner(&mut env, &mut agents, 101, 100, true);
+
+    println!("{} trades of asset 0", env.get_trades(0).len());
+    println!("{} trades of asset 1", env.get_trades(1).len());
+}

--- a/crates/step_sim/examples/random_agents/main.rs
+++ b/crates/step_sim/examples/random_agents/main.rs
@@ -1,8 +1,7 @@
-use bourse_de::agents::{Agent, RandomAgents};
+use bourse_de::agents::{Agent, AgentSet, RandomAgents};
 use bourse_de::{sim_runner, Env};
-use bourse_macros::Agents;
 
-#[derive(Agents)]
+#[derive(AgentSet)]
 struct SimAgents {
     pub a: RandomAgents,
     pub b: RandomAgents,

--- a/crates/step_sim/examples/random_agents/main.rs
+++ b/crates/step_sim/examples/random_agents/main.rs
@@ -2,7 +2,7 @@ use bourse_de::agents::{Agent, AgentSet, RandomAgents};
 use bourse_de::{sim_runner, Env};
 
 #[derive(AgentSet)]
-struct SimAgents {
+struct Agents {
     pub a: RandomAgents,
     pub b: RandomAgents,
 }
@@ -10,7 +10,7 @@ struct SimAgents {
 pub fn main() {
     let mut env = Env::new(0, 1, 1_000_000, true);
 
-    let mut agents = SimAgents {
+    let mut agents = Agents {
         a: RandomAgents::new(50, (40, 60), (10, 20), 2, 0.8),
         b: RandomAgents::new(50, (10, 90), (50, 70), 2, 0.2),
     };

--- a/crates/step_sim/src/agents/mod.rs
+++ b/crates/step_sim/src/agents/mod.rs
@@ -12,8 +12,8 @@ mod noise_agent;
 mod random_agent;
 
 pub use bourse_macros::{AgentSet, MarketAgentSet};
-pub use momentum_agent::{MomentumAgent, MomentumParams};
-pub use noise_agent::{NoiseAgent, NoiseAgentParams};
+pub use momentum_agent::{MomentumAgent, MomentumMarketAgent, MomentumParams};
+pub use noise_agent::{NoiseAgent, NoiseAgentParams, NoiseMarketAgent};
 pub use random_agent::{RandomAgents, RandomMarketAgents};
 
 /// Homogeneous agent set functionality

--- a/crates/step_sim/src/agents/mod.rs
+++ b/crates/step_sim/src/agents/mod.rs
@@ -20,7 +20,7 @@ pub use random_agent::{RandomAgents, RandomMarketAgents};
 ///
 /// A set of agents that implement this trait
 /// can then be included in a struct using the
-/// [Agents] macro to combine multiple agent
+/// [AgentSet] macro to combine multiple agent
 /// types.
 ///
 /// # Examples
@@ -63,7 +63,7 @@ pub trait Agent {
 ///
 /// It's a common case that we want update to update
 /// a heterogeneous set of agents which can be
-/// automatically implemented with the [Agents] macro
+/// automatically implemented with the [AgentSet] macro
 /// as long as the agent types implement the [Agent]
 /// trait.
 ///

--- a/crates/step_sim/src/agents/mod.rs
+++ b/crates/step_sim/src/agents/mod.rs
@@ -14,7 +14,7 @@ mod random_agent;
 pub use bourse_macros::{AgentSet, MarketAgentSet};
 pub use momentum_agent::{MomentumAgent, MomentumParams};
 pub use noise_agent::{NoiseAgent, NoiseAgentParams};
-pub use random_agent::RandomAgents;
+pub use random_agent::{RandomAgents, RandomMarketAgents};
 
 /// Homogeneous agent set functionality
 ///

--- a/crates/step_sim/src/agents/momentum_agent.rs
+++ b/crates/step_sim/src/agents/momentum_agent.rs
@@ -248,15 +248,15 @@ impl Agent for MomentumAgent {
 /// # Examples
 ///
 /// ```
-/// use bourse_de::agents::{Agent, AgentSet, MomentumAgent, MomentumParams};
-/// use bourse_de::{sim_runner, Env};
+/// use bourse_de::agents::{MarketAgent, MarketAgentSet, MomentumMarketAgent, MomentumParams};
+/// use bourse_de::{market_sim_runner, MarketEnv};
 ///
-/// #[derive(AgentSet)]
-/// struct SimAgents {
-///     pub a: MomentumAgent,
+/// #[derive(MarketAgentSet)]
+/// struct Agents {
+///     pub a: MomentumMarketAgent,
 /// }
 ///
-/// let mut env = Env::new(0, 1, 1_000_000, true);
+/// let mut env = MarketEnv::<1>::new(0, [1], 1_000_000, true);
 ///
 /// let params = MomentumParams {
 ///     tick_size: 2,
@@ -269,11 +269,11 @@ impl Agent for MomentumAgent {
 ///     price_dist_mu: 0.0,
 ///     price_dist_sigma: 10.0,
 /// };
-/// let mut agents = SimAgents {
-///     a: MomentumAgent::new(0, 5, params),
+/// let mut agents = Agents {
+///     a: MomentumMarketAgent::new(0, 5, 0, params),
 /// };
 ///
-/// sim_runner(&mut env, &mut agents, 101, 10, false);
+/// market_sim_runner(&mut env, &mut agents, 101, 10, false);
 /// ```
 /// # References
 ///

--- a/crates/step_sim/src/agents/momentum_agent.rs
+++ b/crates/step_sim/src/agents/momentum_agent.rs
@@ -1,7 +1,11 @@
 use super::common;
 use super::Agent;
+use super::MarketAgent;
 use crate::types::{OrderId, Price, Side, TraderId, Vol};
 use crate::Env;
+use crate::MarketEnv;
+use bourse_book::types::AssetIdx;
+use bourse_book::types::MarketOrderId;
 use rand::{Rng, RngCore};
 use rand_distr::LogNormal;
 
@@ -193,6 +197,206 @@ impl Agent for MomentumAgent {
                 } else if m < 0.0 {
                     env.place_order(Side::Ask, self.params.trade_vol, *trader_id, None)
                         .unwrap();
+                }
+            }
+        }
+
+        self.momentum = m;
+        self.last_price = Some(mid_price);
+
+        self.orders = live_orders;
+    }
+}
+
+/// Agents that place trades conditioned on price history
+///
+/// A group of agents that track trends in price movements.
+///
+/// The momentum of the price, `M`, is updated each step
+///
+/// ```notrust
+/// M = m * (1 - decay) + decay * (P - p)
+/// ```
+/// where `M` and `P` are the current momentum and price,
+/// and `m` and `p` are the values at the previous step.
+///
+/// The probability an agent places a market order is then
+/// given by
+///
+/// ```notrust
+/// p_market = demand * tanh(scale * M) / n
+/// ```
+/// where `n` is the number of agents. The probability of
+/// placing a limit order is then given by
+///
+/// ```notrust
+/// p_limit = p_market * order_ratio
+/// ```
+///
+/// Agents will then place a buy/sell order if `M` is
+/// greater/less than 0.0 respectively.
+///
+/// Each step the agent(s)
+///
+/// - Randomly select existing limit orders for cancellation
+/// - Calculate updated values for `M` and `p_market`.
+/// - Place limit orders with probability `p_limit`
+///   conditional on `M`
+/// - Place market orders with probability `p_market`
+///   conditional on `M`
+///
+/// # Examples
+///
+/// ```
+/// use bourse_de::agents::{Agent, AgentSet, MomentumAgent, MomentumParams};
+/// use bourse_de::{sim_runner, Env};
+///
+/// #[derive(AgentSet)]
+/// struct SimAgents {
+///     pub a: MomentumAgent,
+/// }
+///
+/// let mut env = Env::new(0, 1, 1_000_000, true);
+///
+/// let params = MomentumParams {
+///     tick_size: 2,
+///     p_cancel: 0.1,
+///     trade_vol: 100,
+///     decay: 1.0,
+///     demand: 5.0,
+///     scale: 0.5,
+///     order_ratio: 1.0,
+///     price_dist_mu: 0.0,
+///     price_dist_sigma: 10.0,
+/// };
+/// let mut agents = SimAgents {
+///     a: MomentumAgent::new(0, 5, params),
+/// };
+///
+/// sim_runner(&mut env, &mut agents, 101, 10, false);
+/// ```
+/// # References
+///
+/// 1. <https://arxiv.org/abs/2208.13654>
+///
+pub struct MomentumMarketAgent {
+    price_dist: LogNormal<f64>,
+    orders: Vec<MarketOrderId>,
+    trader_ids: Vec<TraderId>,
+    last_price: Option<f64>,
+    momentum: f64,
+    n: f64,
+    asset: AssetIdx,
+    tick_size: f64,
+    params: MomentumParams,
+}
+
+impl MomentumMarketAgent {
+    /// Initialise a set of momentum traders
+    ///
+    /// # Arguments
+    ///
+    /// - `agent_id_start` = Starting id number of these agents
+    /// - `n_agents` - Number of agents in this set
+    /// - `asset` -
+    /// - `params` - Algorithm parameters, see [MomentumParams]
+    ///
+    pub fn new(
+        agent_id_start: TraderId,
+        n_agents: u16,
+        asset: AssetIdx,
+        params: MomentumParams,
+    ) -> Self {
+        let trader_ids = (agent_id_start..agent_id_start + TraderId::from(n_agents)).collect();
+
+        Self {
+            price_dist: LogNormal::<f64>::new(params.price_dist_mu, params.price_dist_sigma)
+                .unwrap(),
+            orders: Vec::new(),
+            trader_ids,
+            last_price: None,
+            momentum: 0.0,
+            n: n_agents.into(),
+            asset,
+            tick_size: params.tick_size.into(),
+            params,
+        }
+    }
+}
+
+impl MarketAgent for MomentumMarketAgent {
+    fn update<R: RngCore, const M: usize, const N: usize>(
+        &mut self,
+        env: &mut MarketEnv<M, N>,
+        rng: &mut R,
+    ) {
+        let mut live_orders =
+            common::cancel_live_orders_market(env, rng, &self.orders, self.params.p_cancel);
+
+        let mid_price = env.get_market().get_order_book(self.asset).mid_price();
+
+        let (m, p_market) = match self.last_price {
+            Some(p) => {
+                let m =
+                    self.momentum * (1.0 - self.params.decay) + self.params.decay * (mid_price - p);
+                let p = self.params.demand * f64::tanh(self.params.scale * m) / self.n;
+                (m, p)
+            }
+            None => (0.0, 0.0),
+        };
+
+        let p_limit = self.params.order_ratio * p_market;
+
+        for trader_id in self.trader_ids.iter() {
+            if rng.gen::<f64>() < p_limit {
+                if m > 0.0 {
+                    let order_id = common::place_buy_limit_order_market(
+                        env,
+                        rng,
+                        self.price_dist,
+                        mid_price,
+                        self.tick_size,
+                        self.params.trade_vol,
+                        self.asset,
+                        *trader_id,
+                    )
+                    .unwrap();
+                    live_orders.push(order_id);
+                } else if m < 0.0 {
+                    let order_id = common::place_sell_limit_order_market(
+                        env,
+                        rng,
+                        self.price_dist,
+                        mid_price,
+                        self.tick_size,
+                        self.params.trade_vol,
+                        self.asset,
+                        *trader_id,
+                    )
+                    .unwrap();
+                    live_orders.push(order_id);
+                }
+            }
+
+            if rng.gen::<f64>() < p_market {
+                if m > 0.0 {
+                    env.place_order(
+                        self.asset,
+                        Side::Bid,
+                        self.params.trade_vol,
+                        *trader_id,
+                        None,
+                    )
+                    .unwrap();
+                } else if m < 0.0 {
+                    env.place_order(
+                        self.asset,
+                        Side::Ask,
+                        self.params.trade_vol,
+                        *trader_id,
+                        None,
+                    )
+                    .unwrap();
                 }
             }
         }

--- a/crates/step_sim/src/agents/momentum_agent.rs
+++ b/crates/step_sim/src/agents/momentum_agent.rs
@@ -7,7 +7,7 @@ use rand_distr::LogNormal;
 
 /// Momentum agent parameters
 ///
-/// See [MomentumAgent] for details of the
+/// See [MomentumAgent] for details of how
 /// these parameters are used.
 pub struct MomentumParams {
     /// Integer market tick-size
@@ -72,9 +72,8 @@ pub struct MomentumParams {
 /// ```
 /// use bourse_de::agents::{Agent, AgentSet, MomentumAgent, MomentumParams};
 /// use bourse_de::{sim_runner, Env};
-/// use bourse_macros::Agents;
 ///
-/// #[derive(Agents)]
+/// #[derive(AgentSet)]
 /// struct SimAgents {
 ///     pub a: MomentumAgent,
 /// }

--- a/crates/step_sim/src/agents/noise_agent.rs
+++ b/crates/step_sim/src/agents/noise_agent.rs
@@ -1,8 +1,11 @@
 //! Agent that randomly places and cancels limit and market orders
 use super::common;
 use super::Agent;
-use crate::types::{OrderId, Price, Side, TraderId, Vol};
+use super::MarketAgent;
+use crate::types::{AssetIdx, OrderId, Price, Side, TraderId, Vol};
 use crate::Env;
+use crate::MarketEnv;
+use bourse_book::types::MarketOrderId;
 use rand::Rng;
 use rand::RngCore;
 use rand_distr::LogNormal;
@@ -46,7 +49,7 @@ pub struct NoiseAgentParams {
 /// use bourse_de::{sim_runner, Env};
 ///
 /// #[derive(AgentSet)]
-/// struct SimAgents {
+/// struct Agents {
 ///     pub a: NoiseAgent,
 /// }
 ///
@@ -61,7 +64,7 @@ pub struct NoiseAgentParams {
 ///     price_dist_mu: 0.0,
 ///     price_dist_sigma: 1.0,
 /// };
-/// let mut agents = SimAgents {
+/// let mut agents = Agents {
 ///     a: NoiseAgent::new(0, 5, params),
 /// };
 ///
@@ -164,6 +167,178 @@ impl Agent for NoiseAgent {
                         .unwrap(),
                     false => env
                         .place_order(Side::Ask, self.params.trade_vol, *trader_id, None)
+                        .unwrap(),
+                };
+            }
+        }
+
+        self.orders = live_orders;
+    }
+}
+
+/// Agent(s) that randomly place and cancel limit and market orders
+///
+/// Represents a group of agents that randomly place and cancel
+/// orders at each step of the simulation. Each step:
+///
+/// - Any currently live orders are randomly selected for cancellation
+/// - Each agent randomly chooses to place a limit order, if so they
+///   place an order on a random side with a price above/below the
+///   mid-price by a distance sampled from a log-normal distribution
+/// - Each agent randomly chooses to place a market order, if so they
+///   place an order on a random side
+///
+/// In both cases orders are placed at a fixed size.
+///
+/// # Examples
+///
+/// ```
+/// use bourse_de::agents::{Agent, AgentSet, NoiseAgent, NoiseAgentParams};
+/// use bourse_de::{sim_runner, Env};
+///
+/// #[derive(AgentSet)]
+/// struct Agents {
+///     pub a: NoiseAgent,
+/// }
+///
+/// let mut env = Env::new(0, 1, 1_000_000, true);
+///
+/// let params = NoiseAgentParams{
+///     tick_size: 2,
+///     p_limit: 0.2,
+///     p_market: 0.2,
+///     p_cancel: 0.1,
+///     trade_vol: 100,
+///     price_dist_mu: 0.0,
+///     price_dist_sigma: 1.0,
+/// };
+/// let mut agents = Agents {
+///     a: NoiseAgent::new(0, 5, params),
+/// };
+///
+/// sim_runner(&mut env, &mut agents, 101, 10, false);
+/// ```
+///
+/// # References
+///
+/// 1. <https://arxiv.org/abs/2208.13654>
+///
+pub struct NoiseMarketAgent {
+    asset: AssetIdx,
+    tick_size: f64,
+    price_dist: LogNormal<f64>,
+    orders: Vec<MarketOrderId>,
+    trader_ids: Vec<TraderId>,
+    params: NoiseAgentParams,
+}
+
+impl NoiseMarketAgent {
+    /// Initialise a group of noise-agents
+    ///
+    /// # Parameters
+    ///
+    /// - `agent_id_start` - Starting id for
+    ///   agents in this set
+    /// - `n_agents` - Number of agents
+    /// - `p_limit` - Probability each agent places
+    ///   a new limit order each step
+    /// - `p_market` - Probability each agent places
+    ///   a new market order each step
+    /// - `p_cancel` - Probability of cancelling a
+    ///   live order
+    /// - `trade_vol` - Size of orders placed by
+    ///   the agents
+    /// - `tick_size` - Integer tick-size of the
+    ///   market
+    /// - `price_dist_mu` - Mean parameter of the
+    ///   log-normal distribution that limit-order
+    ///   prices are sampled from
+    /// - `price_dist_sigma` - Width parameter of the
+    ///   log-normal distribution that limit-order
+    ///   prices are sampled from
+    ///
+    pub fn new(
+        asset: AssetIdx,
+        agent_id_start: TraderId,
+        n_agents: u16,
+        params: NoiseAgentParams,
+    ) -> Self {
+        let trader_ids = (agent_id_start..agent_id_start + TraderId::from(n_agents)).collect();
+
+        Self {
+            asset,
+            tick_size: params.tick_size.into(),
+            price_dist: LogNormal::<f64>::new(params.price_dist_mu, params.price_dist_sigma)
+                .unwrap(),
+            orders: Vec::new(),
+            trader_ids,
+            params,
+        }
+    }
+}
+
+impl MarketAgent for NoiseMarketAgent {
+    fn update<R: RngCore, const M: usize, const N: usize>(
+        &mut self,
+        env: &mut MarketEnv<M, N>,
+        rng: &mut R,
+    ) {
+        let mut live_orders =
+            common::cancel_live_orders_market(env, rng, &self.orders, self.params.p_cancel);
+
+        let mid_price = env.get_market().get_order_book(self.asset).mid_price();
+
+        for trader_id in self.trader_ids.iter() {
+            if rng.gen::<f32>() < self.params.p_limit {
+                let side = rng.gen_bool(0.5);
+
+                let order_id = match side {
+                    true => common::place_buy_limit_order_market(
+                        env,
+                        rng,
+                        self.price_dist,
+                        mid_price,
+                        self.tick_size,
+                        self.params.trade_vol,
+                        self.asset,
+                        *trader_id,
+                    )
+                    .unwrap(),
+                    false => common::place_sell_limit_order_market(
+                        env,
+                        rng,
+                        self.price_dist,
+                        mid_price,
+                        self.tick_size,
+                        self.params.trade_vol,
+                        self.asset,
+                        *trader_id,
+                    )
+                    .unwrap(),
+                };
+                live_orders.push(order_id);
+            }
+
+            if rng.gen::<f32>() < self.params.p_market {
+                let side = rng.gen_bool(0.5);
+                match side {
+                    true => env
+                        .place_order(
+                            self.asset,
+                            Side::Bid,
+                            self.params.trade_vol,
+                            *trader_id,
+                            None,
+                        )
+                        .unwrap(),
+                    false => env
+                        .place_order(
+                            self.asset,
+                            Side::Ask,
+                            self.params.trade_vol,
+                            *trader_id,
+                            None,
+                        )
                         .unwrap(),
                 };
             }

--- a/crates/step_sim/src/agents/noise_agent.rs
+++ b/crates/step_sim/src/agents/noise_agent.rs
@@ -193,15 +193,15 @@ impl Agent for NoiseAgent {
 /// # Examples
 ///
 /// ```
-/// use bourse_de::agents::{Agent, AgentSet, NoiseAgent, NoiseAgentParams};
-/// use bourse_de::{sim_runner, Env};
+/// use bourse_de::agents::{MarketAgent, MarketAgentSet, NoiseMarketAgent, NoiseAgentParams};
+/// use bourse_de::{market_sim_runner, MarketEnv};
 ///
-/// #[derive(AgentSet)]
+/// #[derive(MarketAgentSet)]
 /// struct Agents {
-///     pub a: NoiseAgent,
+///     pub a: NoiseMarketAgent,
 /// }
 ///
-/// let mut env = Env::new(0, 1, 1_000_000, true);
+/// let mut env = MarketEnv::<1>::new(0, [1], 1_000_000, true);
 ///
 /// let params = NoiseAgentParams{
 ///     tick_size: 2,
@@ -213,10 +213,10 @@ impl Agent for NoiseAgent {
 ///     price_dist_sigma: 1.0,
 /// };
 /// let mut agents = Agents {
-///     a: NoiseAgent::new(0, 5, params),
+///     a: NoiseMarketAgent::new(0, 5, 0, params),
 /// };
 ///
-/// sim_runner(&mut env, &mut agents, 101, 10, false);
+/// market_sim_runner(&mut env, &mut agents, 101, 10, false);
 /// ```
 ///
 /// # References

--- a/crates/step_sim/src/agents/noise_agent.rs
+++ b/crates/step_sim/src/agents/noise_agent.rs
@@ -44,9 +44,8 @@ pub struct NoiseAgentParams {
 /// ```
 /// use bourse_de::agents::{Agent, AgentSet, NoiseAgent, NoiseAgentParams};
 /// use bourse_de::{sim_runner, Env};
-/// use bourse_macros::Agents;
 ///
-/// #[derive(Agents)]
+/// #[derive(AgentSet)]
 /// struct SimAgents {
 ///     pub a: NoiseAgent,
 /// }

--- a/crates/step_sim/src/agents/random_agent.rs
+++ b/crates/step_sim/src/agents/random_agent.rs
@@ -29,10 +29,10 @@ use rand::RngCore;
 /// # Examples
 ///
 /// ```
-/// use bourse_de::agents::{Agent, RandomAgents, Agents};
+/// use bourse_de::agents::{Agent, RandomAgents, AgentSet};
 /// use bourse_de::{sim_runner, Env};
 ///
-/// #[derive(Agents)]
+/// #[derive(AgentSet)]
 /// struct SimAgents {
 ///     pub a: RandomAgents,
 /// }

--- a/crates/step_sim/src/data.rs
+++ b/crates/step_sim/src/data.rs
@@ -1,0 +1,57 @@
+//! Market data recording
+use crate::types::{Level2Data, OrderCount, Price, Vol};
+use std::array;
+
+/// Market data history recording
+///
+/// History of level 2 data over the course of
+/// the existence of this environment.
+pub struct Level2DataRecords<const N: usize> {
+    /// Touch price histories
+    pub prices: (Vec<Price>, Vec<Price>),
+    /// Bid-ask volume histories
+    pub volumes: (Vec<Vol>, Vec<Vol>),
+    /// Volumes at price levels
+    pub volumes_at_levels: ([Vec<Vol>; N], [Vec<Vol>; N]),
+    /// numbers of orders at price levels
+    pub orders_at_levels: ([Vec<OrderCount>; N], [Vec<OrderCount>; N]),
+}
+
+impl<const N: usize> Default for Level2DataRecords<N> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<const N: usize> Level2DataRecords<N> {
+    /// Initialise an empty set of records
+    pub fn new() -> Self {
+        Self {
+            prices: (Vec::new(), Vec::new()),
+            volumes: (Vec::new(), Vec::new()),
+            volumes_at_levels: (
+                array::from_fn(|_| Vec::new()),
+                array::from_fn(|_| Vec::new()),
+            ),
+            orders_at_levels: (
+                array::from_fn(|_| Vec::new()),
+                array::from_fn(|_| Vec::new()),
+            ),
+        }
+    }
+
+    /// Append a record to the history
+    pub fn append_record(&mut self, record: &Level2Data<N>) {
+        self.prices.0.push(record.bid_price);
+        self.prices.1.push(record.ask_price);
+        self.volumes.0.push(record.bid_vol);
+        self.volumes.1.push(record.ask_vol);
+        for i in 0..N {
+            self.volumes_at_levels.0[i].push(record.bid_price_levels[i].0);
+            self.orders_at_levels.0[i].push(record.bid_price_levels[i].1);
+
+            self.volumes_at_levels.1[i].push(record.ask_price_levels[i].0);
+            self.orders_at_levels.1[i].push(record.ask_price_levels[i].1);
+        }
+    }
+}

--- a/crates/step_sim/src/env.rs
+++ b/crates/step_sim/src/env.rs
@@ -4,61 +4,14 @@
 //! functionality to process instructions
 //! submitted by agents and to track market data
 //!
+use super::data::Level2DataRecords;
 use crate::types::{
     Event, Level2Data, Nanos, Order, OrderCount, OrderId, Price, Side, Status, Trade, TraderId, Vol,
 };
 use bourse_book::{OrderBook, OrderError};
 use rand::seq::SliceRandom;
 use rand::RngCore;
-use std::{array, mem};
-
-/// Market data history recording
-///
-/// History of level 2 data over the course of
-/// the existence of this environment.
-pub struct Level2DataRecords<const N: usize> {
-    /// Touch price histories
-    pub prices: (Vec<Price>, Vec<Price>),
-    /// Bid-ask volume histories
-    pub volumes: (Vec<Vol>, Vec<Vol>),
-    /// Volumes at price levels
-    pub volumes_at_levels: ([Vec<Vol>; N], [Vec<Vol>; N]),
-    /// numbers of orders at price levels
-    pub orders_at_levels: ([Vec<OrderCount>; N], [Vec<OrderCount>; N]),
-}
-
-impl<const N: usize> Level2DataRecords<N> {
-    /// Initialise an empty set of records
-    fn new() -> Self {
-        Self {
-            prices: (Vec::new(), Vec::new()),
-            volumes: (Vec::new(), Vec::new()),
-            volumes_at_levels: (
-                array::from_fn(|_| Vec::new()),
-                array::from_fn(|_| Vec::new()),
-            ),
-            orders_at_levels: (
-                array::from_fn(|_| Vec::new()),
-                array::from_fn(|_| Vec::new()),
-            ),
-        }
-    }
-
-    /// Append a record to the history
-    fn append_record(&mut self, record: &Level2Data<N>) {
-        self.prices.0.push(record.bid_price);
-        self.prices.1.push(record.ask_price);
-        self.volumes.0.push(record.bid_vol);
-        self.volumes.1.push(record.ask_vol);
-        for i in 0..N {
-            self.volumes_at_levels.0[i].push(record.bid_price_levels[i].0);
-            self.orders_at_levels.0[i].push(record.bid_price_levels[i].1);
-
-            self.volumes_at_levels.1[i].push(record.ask_price_levels[i].0);
-            self.orders_at_levels.1[i].push(record.ask_price_levels[i].1);
-        }
-    }
-}
+use std::mem;
 
 /// Discrete event simulation environment
 ///
@@ -106,9 +59,6 @@ pub struct Env<const N: usize = 10> {
 }
 
 impl<const N: usize> Env<N> {
-    /// Number of price levels recorded during simulation
-    pub const N_LEVELS: usize = N;
-
     /// Initialise an empty environment
     ///
     /// # Arguments

--- a/crates/step_sim/src/env.rs
+++ b/crates/step_sim/src/env.rs
@@ -43,22 +43,34 @@ use std::mem;
 /// // Update the state of the market
 /// env.step(&mut rng)
 /// ```
-pub struct Env<const N: usize = 10> {
+///
+/// The number of price levels recorded as part
+/// of the level-2 data can be customised
+/// using the `LEVELS` constant, for example:
+///
+/// ```
+/// use bourse_de::Env;
+///
+/// // Record 5 price levels
+/// let env = Env::<5>::new(0, 1, 1_000, true);
+/// ```
+///
+pub struct Env<const LEVELS: usize = 10> {
     /// Time-length of each simulation step
     step_size: Nanos,
     /// Simulated order book
-    order_book: OrderBook<N>,
+    order_book: OrderBook<LEVELS>,
     /// Per step trade volume histories
     trade_vols: Vec<Vol>,
     /// Transaction queue
-    transactions: Vec<Event>,
+    transactions: Vec<Event<OrderId>>,
     /// Current level 2 market data
-    level_2_data: Level2Data<N>,
+    level_2_data: Level2Data<LEVELS>,
     /// Level 2 data history
-    level_2_data_records: Level2DataRecords<N>,
+    level_2_data_records: Level2DataRecords<LEVELS>,
 }
 
-impl<const N: usize> Env<N> {
+impl<const LEVELS: usize> Env<LEVELS> {
     /// Initialise an empty environment
     ///
     /// # Arguments
@@ -216,7 +228,7 @@ impl<const N: usize> Env<N> {
         &self.level_2_data_records.volumes
     }
 
-    /// Get bid-ask touch histories
+    /// Get bid-ask touch volume histories
     pub fn get_touch_volumes(&self) -> (&Vec<Vol>, &Vec<Vol>) {
         (
             &self.level_2_data_records.volumes_at_levels.0[0],
@@ -224,7 +236,7 @@ impl<const N: usize> Env<N> {
         )
     }
 
-    /// Get bid-ask order_count histories
+    /// Get bid-ask order-count histories
     pub fn get_touch_order_counts(&self) -> (&Vec<OrderCount>, &Vec<OrderCount>) {
         (
             &self.level_2_data_records.orders_at_levels.0[0],
@@ -243,12 +255,12 @@ impl<const N: usize> Env<N> {
     }
 
     /// Get reference to the underlying orderbook
-    pub fn get_orderbook(&self) -> &OrderBook<N> {
+    pub fn get_orderbook(&self) -> &OrderBook<LEVELS> {
         &self.order_book
     }
 
     /// Get level 2 data history
-    pub fn get_level_2_data_history(&self) -> &Level2DataRecords<N> {
+    pub fn get_level_2_data_history(&self) -> &Level2DataRecords<LEVELS> {
         &self.level_2_data_records
     }
 
@@ -278,12 +290,12 @@ impl<const N: usize> Env<N> {
     }
 
     /// Reference to current level-2 market data
-    pub fn level_2_data(&self) -> &Level2Data<N> {
+    pub fn level_2_data(&self) -> &Level2Data<LEVELS> {
         &self.level_2_data
     }
 
     #[cfg(test)]
-    pub fn get_transactions(&self) -> &Vec<Event> {
+    pub fn get_transactions(&self) -> &Vec<Event<OrderId>> {
         &self.transactions
     }
 }

--- a/crates/step_sim/src/lib.rs
+++ b/crates/step_sim/src/lib.rs
@@ -148,4 +148,4 @@ pub use bourse_book::{types, OrderError};
 pub use data::Level2DataRecords;
 pub use env::Env;
 pub use market_env::MarketEnv;
-pub use runner::sim_runner;
+pub use runner::{market_sim_runner, sim_runner};

--- a/crates/step_sim/src/lib.rs
+++ b/crates/step_sim/src/lib.rs
@@ -37,14 +37,14 @@
 //! ```
 //! use bourse_de::types::{Price, Side, Vol};
 //! use bourse_de::agents;
-//! use bourse_de::agents::Agent;
+//! use bourse_de::agents::{Agent, AgentSet};
 //! use bourse_de::{sim_runner, Env};
 //! use rand::{RngCore, Rng};
 //!
 //! // Define a set of agents using built
 //! // in definitions
-//! #[derive(agents::Agents)]
-//! struct SimAgents {
+//! #[derive(AgentSet)]
+//! struct Agents {
 //!     pub a: agents::MomentumAgent,
 //!     pub b: agents::NoiseAgent,
 //! }
@@ -72,7 +72,7 @@
 //!     price_dist_sigma: 1.0,
 //! };
 //!
-//! let mut agents = SimAgents {
+//! let mut agents = Agents {
 //!     a: agents::MomentumAgent::new(0, 10, m_params),
 //!     b: agents::NoiseAgent::new(10, 20, n_params),
 //! };
@@ -99,7 +99,7 @@
 //!
 //! ```
 //! use bourse_de::{Env, sim_runner};
-//! use bourse_de::agents::{Agent, AgentSet, Agents};
+//! use bourse_de::agents::{Agent, AgentSet};
 //! use rand::RngCore;
 //!
 //! struct AgentTypeA{}
@@ -118,14 +118,14 @@
 //!     ) {}
 //! }
 //!
-//! #[derive(Agents)]
-//! struct SimAgents {
+//! #[derive(AgentSet)]
+//! struct Agents {
 //!     pub a: AgentTypeA,
 //!     pub b: AgentTypeB,
 //! }
 //!
 //! let mut env = bourse_de::Env::new(0, 1, 1_000_000, true);
-//! let mut agents = SimAgents{a: AgentTypeA{}, b: AgentTypeB{}};
+//! let mut agents = Agents{a: AgentTypeA{}, b: AgentTypeB{}};
 //!
 //! sim_runner(&mut env, &mut agents, 101, 50, true);
 //! ```

--- a/crates/step_sim/src/lib.rs
+++ b/crates/step_sim/src/lib.rs
@@ -139,9 +139,13 @@
 //!
 
 pub mod agents;
+mod data;
 mod env;
+mod market_env;
 mod runner;
 
 pub use bourse_book::{types, OrderError};
+pub use data::Level2DataRecords;
 pub use env::Env;
+pub use market_env::MarketEnv;
 pub use runner::sim_runner;

--- a/crates/step_sim/src/lib.rs
+++ b/crates/step_sim/src/lib.rs
@@ -1,8 +1,8 @@
 //! Discrete event market simulation library
 //!
-//! Implements a discrete event simulation
-//! environment ([Env]) and utilities for writing
-//! discrete event market simulations.
+//! Implements discrete event simulation
+//! environments ([Env] and [MarketEnv]) and utilities
+//! for writing discrete event market simulations.
 //!
 //! # Model
 //!
@@ -93,7 +93,7 @@
 //! trait. For a set of homogeneous agents (i.e. all the agents are the
 //! same type) this can be implemented directly.
 //!
-//! For a mixture of agent types, the [agents::Agents] macro can be used
+//! For a mixture of agent types, the [agents::AgentSet] macro can be used
 //! to automatically implement [agents::AgentSet] for a struct of agents
 //! all implementing [agents::Agent]. For examples
 //!
@@ -128,6 +128,37 @@
 //! let mut agents = Agents{a: AgentTypeA{}, b: AgentTypeB{}};
 //!
 //! sim_runner(&mut env, &mut agents, 101, 50, true);
+//! ```
+//!
+//! # Multi-Asset Simulation
+//!
+//! Simulations with multiple assets can be run in an equivalent
+//! manner using the multi-asset [MarketEnv]. There are
+//! also equivalent definitions of [agents::MarketAgentSet] and
+//! [market_sim_runner], for example
+//!
+//! ```
+//! use bourse_de::{MarketEnv, market_sim_runner, agents};
+//! use bourse_de::agents::MarketAgent;
+//! use rand::RngCore;
+//!
+//! struct AgentType{}
+//!
+//! impl agents::MarketAgent for AgentType{
+//!     fn update<R: RngCore, const M: usize, const N: usize>(
+//!         &mut self, env: &mut MarketEnv<M, N>, rng: &mut R
+//!     ) {}
+//! }
+//!
+//! #[derive(agents::MarketAgentSet)]
+//! struct Agents {
+//!     pub a: AgentType,
+//! }
+//!
+//! let mut env = MarketEnv::<4>::new(0, [1, 1, 1, 1], 1_000_000, true);
+//! let mut agents = Agents{a: AgentType{}};
+//!
+//! market_sim_runner(&mut env, &mut agents, 101, 50, true);
 //! ```
 //!
 //! # Randomness

--- a/crates/step_sim/src/market_env.rs
+++ b/crates/step_sim/src/market_env.rs
@@ -1,0 +1,413 @@
+//! Multi-asset discrete event simulation environment
+//!
+//! Wraps a [Market] and provides
+//! functionality to process instructions
+//! submitted by agents and to track market data
+//!
+use super::data::Level2DataRecords;
+use crate::types::{
+    AssetIdx, Level2Data, MarketEvent, Nanos, Order, OrderCount, Price, Side, Status, Trade,
+    TraderId, Vol,
+};
+use bourse_book::{types::MarketOrderId, Market, OrderError};
+use rand::seq::SliceRandom;
+use rand::RngCore;
+use std::{array, mem};
+
+/// Multi-asset discrete event simulation environment
+///
+/// Simulation environment designed for use in a
+/// discrete event simulation. Allows agents/users
+/// to submit order instructions, update
+/// the state of the simulation, and record the
+/// market data.
+///
+/// # Examples
+///
+/// ```
+/// use bourse_de;
+/// use bourse_de::{types, Env};
+/// use rand_xoshiro::Xoroshiro128StarStar;
+/// use rand_xoshiro::rand_core::SeedableRng;
+///
+/// let mut env: Env = Env::new(0, 1, 1_000, true);
+/// let mut rng = Xoroshiro128StarStar::seed_from_u64(101);
+///
+/// // Submit a new order instruction
+/// let order_id = env.place_order(
+///     types::Side::Ask,
+///     100,
+///     101,
+///     Some(50),
+/// );
+///
+/// // Update the state of the market
+/// env.step(&mut rng)
+/// ```
+pub struct MarketEnv<const ASSETS: usize, const LEVELS: usize = 10> {
+    /// Time-length of each simulation step
+    step_size: Nanos,
+    /// Simulated market
+    market: Market<ASSETS, LEVELS>,
+    /// Per step trade volume histories
+    trade_vols: [Vec<Vol>; ASSETS],
+    /// Transaction queue
+    transactions: Vec<MarketEvent>,
+    /// Current level 2 market data
+    level_2_data: [Level2Data<LEVELS>; ASSETS],
+    /// Level 2 data history
+    level_2_data_records: [Level2DataRecords<LEVELS>; ASSETS],
+}
+
+impl<const ASSETS: usize, const LEVELS: usize> MarketEnv<ASSETS, LEVELS> {
+    pub const N_ASSETS: usize = ASSETS;
+    pub const N_LEVELS: usize = LEVELS;
+
+    /// Initialise an empty market environment
+    ///
+    /// # Arguments
+    ///
+    /// - `start_time` - Simulation start time
+    /// - `tick_sizes` - Array of market tick sizes per asset
+    /// - `step_size` - Simulated step time-length
+    /// - `trading` - Flag if `true` orders will be matched,
+    ///   otherwise no trades will take place
+    ///
+    pub fn new(
+        start_time: Nanos,
+        tick_sizes: [Price; ASSETS],
+        step_size: Nanos,
+        trading: bool,
+    ) -> Self {
+        let market = Market::<ASSETS, LEVELS>::new(start_time, tick_sizes, trading);
+        let level_2_data = market.level_2_data();
+        Self {
+            step_size,
+            market,
+            trade_vols: array::from_fn(|_| Vec::new()),
+            transactions: Vec::new(),
+            level_2_data,
+            level_2_data_records: array::from_fn(|_| Level2DataRecords::new()),
+        }
+    }
+
+    /// Update the state of the simulation
+    ///
+    /// Each step of the simulation:
+    ///
+    /// - The cumulative trade volume is reset
+    /// - The transaction queue is shuffled
+    /// - The transactions are processed, updating
+    ///   the state of the market
+    /// - Time is jumped forward to the next step
+    /// - Market data for the step is recorded
+    ///
+    /// Note that when each event is processed time
+    /// is incremented by 1 time unit (to ensure
+    /// orders have a unique index).
+    ///
+    /// # Arguments
+    ///
+    /// - `rng` - Random generator
+    ///
+    pub fn step<R: RngCore>(&mut self, rng: &mut R) {
+        let start_time = self.market.get_time();
+        self.market.reset_trade_vols();
+
+        let mut transactions = mem::take(&mut self.transactions);
+        transactions.shuffle(rng);
+
+        for (i, t) in transactions.into_iter().enumerate() {
+            self.market
+                .set_time(start_time + Nanos::try_from(i).unwrap());
+            self.market.process_event(t);
+        }
+
+        self.market.set_time(start_time + self.step_size);
+
+        self.level_2_data = self.market.level_2_data();
+        let trade_vols = self.market.get_trade_vols();
+
+        for (i, tv) in trade_vols.into_iter().enumerate().take(ASSETS) {
+            self.level_2_data_records[i].append_record(&self.level_2_data[i]);
+            self.trade_vols[i].push(tv);
+        }
+    }
+
+    /// Enable trading
+    pub fn enable_trading(&mut self) {
+        self.market.enable_trading();
+    }
+
+    /// Disable trading
+    pub fn disable_trading(&mut self) {
+        self.market.disable_trading();
+    }
+
+    /// Create a new order
+    ///
+    /// Note that this creates an order but does not
+    /// immediately place the order on the market,
+    /// rather it submits an instruction to place
+    /// the order on the market that will be executed
+    /// during the next update.
+    ///
+    /// Returns the id of the newly create order.
+    ///
+    /// # Arguments
+    ///
+    /// - `side` - Side to place order
+    /// - `vol` - Volume of the order
+    /// - `trader_id` - Id of the trader/agent
+    ///   placing the order
+    /// - `price` - Order price, if None the
+    ///   order will be treated as a market order
+    ///
+    pub fn place_order(
+        &mut self,
+        asset: AssetIdx,
+        side: Side,
+        vol: Vol,
+        trader_id: TraderId,
+        price: Option<Price>,
+    ) -> Result<MarketOrderId, OrderError> {
+        let order_id = self
+            .market
+            .create_order(asset, side, vol, trader_id, price)?;
+        self.transactions.push(MarketEvent::New { order_id });
+        Ok(order_id)
+    }
+
+    /// Submit an instruction to cancel an order
+    ///
+    /// Note that this does not immediately delete
+    /// the order but submits an instruction to cancel
+    /// the order that will be processed during the
+    /// next update
+    ///
+    /// # Arguments
+    ///
+    /// - `order_id` - Id of the order to cancel
+    ///
+    pub fn cancel_order(&mut self, order_id: MarketOrderId) {
+        self.transactions
+            .push(MarketEvent::Cancellation { order_id })
+    }
+
+    /// Submit an instruction to modify an order
+    ///
+    /// Note that this does not immediately modify
+    /// the order but submits an instruction to modify
+    /// the order that will be processed during the
+    /// next update
+    ///
+    /// # Arguments
+    ///
+    /// - `order_id` - Id of the order to modify
+    /// - `new_price` - New price of the order,
+    ///   if `None` the original price will be kept
+    /// - `new_vol` - New volume of the order,
+    ///   if `None` the original price will be kept
+    ///
+    pub fn modify_order(
+        &mut self,
+        order_id: MarketOrderId,
+        new_price: Option<Price>,
+        new_vol: Option<Vol>,
+    ) {
+        self.transactions.push(MarketEvent::Modify {
+            order_id,
+            new_price,
+            new_vol,
+        })
+    }
+
+    /// Get reference to bid-ask price histories of an asset
+    ///
+    /// # Arguments
+    ///
+    /// - `asset` - Index of asset
+    ///
+    pub fn get_prices(&self, asset: AssetIdx) -> &(Vec<Price>, Vec<Price>) {
+        &self.level_2_data_records[asset].prices
+    }
+
+    /// Get bid-ask volume histories of an asset
+    ///
+    /// # Arguments
+    ///
+    /// - `asset` - Index of asset
+    ///
+    pub fn get_volumes(&self, asset: AssetIdx) -> &(Vec<Vol>, Vec<Vol>) {
+        &self.level_2_data_records[asset].volumes
+    }
+
+    /// Get bid-ask touch histories of an asset
+    ///
+    /// # Arguments
+    ///
+    /// - `asset` - Index of asset
+    ///
+    pub fn get_touch_volumes(&self, asset: AssetIdx) -> (&Vec<Vol>, &Vec<Vol>) {
+        (
+            &self.level_2_data_records[asset].volumes_at_levels.0[0],
+            &self.level_2_data_records[asset].volumes_at_levels.1[0],
+        )
+    }
+
+    /// Get bid-ask order_count histories of an asset
+    ///
+    /// # Arguments
+    ///
+    /// - `asset` - Index of asset
+    ///
+    pub fn get_touch_order_counts(&self, asset: AssetIdx) -> (&Vec<OrderCount>, &Vec<OrderCount>) {
+        (
+            &self.level_2_data_records[asset].orders_at_levels.0[0],
+            &self.level_2_data_records[asset].orders_at_levels.1[0],
+        )
+    }
+
+    /// Get per step trade volume histories of an asset
+    ///
+    /// # Arguments
+    ///
+    /// - `asset` - Index of asset
+    ///
+    pub fn get_trade_vols(&self, asset: AssetIdx) -> &Vec<Vol> {
+        &self.trade_vols[asset]
+    }
+
+    /// Get references to order data for an asset
+    ///
+    /// # Arguments
+    ///
+    /// - `asset` - Index of asset
+    ///
+    pub fn get_orders(&self, asset: AssetIdx) -> Vec<&Order> {
+        self.market.get_orders(asset)
+    }
+
+    /// Get a reference to the underlying market
+    pub fn get_market(&self) -> &Market<ASSETS, LEVELS> {
+        &self.market
+    }
+
+    /// Get level 2 data history for an asset
+    ///
+    /// # Arguments
+    ///
+    /// - `asset` - Index of asset
+    ///
+    pub fn get_level_2_data_history(&self, asset: AssetIdx) -> &Level2DataRecords<LEVELS> {
+        &self.level_2_data_records[asset]
+    }
+
+    /// Get reference to trade data for an asset
+    ///
+    /// # Arguments
+    ///
+    /// - `asset` - Index of asset
+    ///
+    pub fn get_trades(&self, asset: AssetIdx) -> &Vec<Trade> {
+        self.market.get_order_book(asset).get_trades()
+    }
+
+    /// Get a reference to an order by id
+    ///
+    /// # Arguments
+    ///
+    /// - `order_id` - Id of an order
+    ///
+    pub fn order(&self, order_id: MarketOrderId) -> &Order {
+        self.market.order(order_id)
+    }
+
+    /// Get the status of an order
+    ///
+    /// # Arguments
+    ///
+    /// - `order_id` - Id of an order
+    ///
+    pub fn order_status(&self, order_id: MarketOrderId) -> Status {
+        self.market.order(order_id).status
+    }
+
+    /// Reference to current level-2 market data
+    pub fn level_2_data(&self) -> &[Level2Data<LEVELS>; ASSETS] {
+        &self.level_2_data
+    }
+
+    #[cfg(test)]
+    pub fn get_transactions(&self) -> &Vec<MarketEvent> {
+        &self.transactions
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bourse_book::types::Status;
+    use rand_xoshiro::rand_core::SeedableRng;
+    use rand_xoshiro::Xoroshiro128StarStar as Rng;
+
+    use super::*;
+
+    #[test]
+    fn test_env() {
+        let step_size: Nanos = 1000;
+        let mut env: MarketEnv<2> = MarketEnv::new(0, [1, 1], step_size, true);
+        let mut rng = Rng::seed_from_u64(101);
+
+        env.place_order(0, Side::Bid, 10, 101, Some(10)).unwrap();
+        env.place_order(0, Side::Ask, 20, 101, Some(20)).unwrap();
+
+        env.step(&mut rng);
+
+        assert!(env.transactions.len() == 0);
+        assert!(env.get_market().bid_asks() == [(10, 20), (0, Price::MAX)]);
+        assert!(env.get_orders(0).len() == 2);
+        assert!(env.get_orders(0)[0].status == Status::Active);
+        assert!(env.get_orders(0)[1].status == Status::Active);
+        assert!(env.get_market().get_time() == step_size);
+
+        env.place_order(0, Side::Bid, 10, 101, Some(11)).unwrap();
+        env.place_order(0, Side::Ask, 20, 101, Some(21)).unwrap();
+
+        env.step(&mut rng);
+
+        assert!(env.get_market().bid_asks() == [(11, 20), (0, Price::MAX)]);
+        assert!(env.get_orders(0).len() == 4);
+        assert!(env.get_market().get_time() == 2 * step_size);
+
+        env.place_order(0, Side::Bid, 30, 101, None).unwrap();
+
+        env.step(&mut rng);
+
+        assert!(env.get_market().bid_asks() == [(11, 21), (0, Price::MAX)]);
+        assert!(env.get_market().ask_vols() == [10, 0]);
+        assert!(env.get_orders(0).len() == 5);
+        assert!(env.get_orders(0)[1].status == Status::Filled);
+        assert!(env.get_orders(0)[4].status == Status::Filled);
+        assert!(env.get_trades(0).len() == 2);
+        assert!(env.get_market().get_time() == 3 * step_size);
+
+        let prices = env.get_prices(0);
+        assert!(prices.0 == vec![10, 11, 11]);
+        assert!(prices.1 == vec![20, 20, 21]);
+
+        let volumes = env.get_volumes(0);
+        assert!(volumes.0 == vec![10, 20, 20]);
+        assert!(volumes.1 == vec![20, 40, 10]);
+
+        let touch_volumes = env.get_touch_volumes(0);
+        assert!(*touch_volumes.0 == vec![10, 10, 10]);
+        assert!(*touch_volumes.1 == vec![20, 20, 10]);
+
+        let touch_order_counts = env.get_touch_order_counts(0);
+        assert!(*touch_order_counts.0 == vec![1, 1, 1]);
+        assert!(*touch_order_counts.1 == vec![1, 1, 1]);
+
+        let trade_vols = env.get_trade_vols(0);
+        assert!(*trade_vols == vec![0, 0, 30]);
+    }
+}

--- a/crates/step_sim/src/market_env.rs
+++ b/crates/step_sim/src/market_env.rs
@@ -60,9 +60,6 @@ pub struct MarketEnv<const ASSETS: usize, const LEVELS: usize = 10> {
 }
 
 impl<const ASSETS: usize, const LEVELS: usize> MarketEnv<ASSETS, LEVELS> {
-    pub const N_ASSETS: usize = ASSETS;
-    pub const N_LEVELS: usize = LEVELS;
-
     /// Initialise an empty market environment
     ///
     /// # Arguments

--- a/crates/step_sim/src/runner.rs
+++ b/crates/step_sim/src/runner.rs
@@ -1,6 +1,7 @@
 //! Simulation execution functionality
-use super::agents::AgentSet;
+use super::agents::{AgentSet, MarketAgentSet};
 use super::env::Env;
+use super::market_env::MarketEnv;
 use kdam::tqdm;
 use rand_xoshiro::rand_core::SeedableRng;
 use rand_xoshiro::Xoroshiro128StarStar;
@@ -44,6 +45,68 @@ use rand_xoshiro::Xoroshiro128StarStar;
 ///
 pub fn sim_runner<A: AgentSet>(
     env: &mut Env,
+    agents: &mut A,
+    seed: u64,
+    n_steps: u64,
+    show_progress: bool,
+) {
+    let mut rng = Xoroshiro128StarStar::seed_from_u64(seed);
+
+    match show_progress {
+        true => {
+            for _ in tqdm!(0..n_steps) {
+                agents.update(env, &mut rng);
+                env.step(&mut rng);
+            }
+        }
+        false => {
+            for _ in 0..n_steps {
+                agents.update(env, &mut rng);
+                env.step(&mut rng);
+            }
+        }
+    }
+}
+
+/// Run a simulation for a fixed number of steps
+///
+/// Each step updates the state of the agents (who
+/// in turn can submit instructions to the environment
+/// and then update the environment state)
+///
+/// # Examples
+///
+/// ```
+/// use bourse_de::{MarketEnv, market_sim_runner};
+/// use bourse_de::agents::MarketAgentSet;
+/// use rand::RngCore;
+///
+/// // Dummy agent-type
+/// struct Agents{}
+///
+/// impl MarketAgentSet for Agents {
+///     fn update<R: RngCore, const M: usize, const N: usize>(
+///         &mut self, _env: &mut MarketEnv<M, N>, _rng: &mut R
+///     ) {}
+/// }
+///
+/// let mut env = bourse_de::MarketEnv::<2>::new(0, [1, 1], 1_000, true);
+/// let mut agents = Agents{};
+///
+/// // Run for 100 steps from seed 101
+/// market_sim_runner(&mut env, &mut agents, 101, 100, true)
+/// ```
+///
+/// # Arguments
+///
+/// - `env` - Simulation environment
+/// - `agents` - Agent(s) implementing the [MarketAgentSet] trait
+/// - `seed` - Random seed
+/// - `n_steps` - Number of simulation steps
+/// - `show_progress` - Show progress bar
+///
+pub fn market_sim_runner<A: MarketAgentSet, const M: usize, const N: usize>(
+    env: &mut MarketEnv<M, N>,
     agents: &mut A,
     seed: u64,
     n_steps: u64,

--- a/crates/step_sim/src/runner.rs
+++ b/crates/step_sim/src/runner.rs
@@ -68,7 +68,7 @@ pub fn sim_runner<A: AgentSet>(
     }
 }
 
-/// Run a simulation for a fixed number of steps
+/// Run a multi-asset simulation for a fixed number of steps
 ///
 /// Each step updates the state of the agents (who
 /// in turn can submit instructions to the environment

--- a/crates/step_sim/tests/test_macros.rs
+++ b/crates/step_sim/tests/test_macros.rs
@@ -1,6 +1,7 @@
 use bourse_book::types::{Price, Side};
-use bourse_de::agents::{Agent, AgentSet, Agents};
-use bourse_de::Env;
+use bourse_de::agents::{Agent, AgentSet, MarketAgent, MarketAgentSet};
+use bourse_de::types::AssetIdx;
+use bourse_de::{Env, MarketEnv};
 use rand::RngCore;
 use rand_xoshiro::rand_core::SeedableRng;
 use rand_xoshiro::Xoroshiro128StarStar;
@@ -25,7 +26,7 @@ impl Agent for TestAgent {
 
 #[test]
 fn test_agent_macro() {
-    #[derive(Agents)]
+    #[derive(AgentSet)]
     struct TestAgents {
         pub a: TestAgent,
         pub b: TestAgent,
@@ -52,4 +53,62 @@ fn test_agent_macro() {
     assert!(env.get_orderbook().ask_vol() == 20);
     assert!(env.get_orderbook().bid_vol() == 20);
     assert!(env.get_orderbook().bid_ask() == (20, 40));
+}
+
+struct MarketTestAgent {
+    asset: AssetIdx,
+    side: Side,
+    price: Price,
+}
+
+impl MarketTestAgent {
+    pub fn new(asset: AssetIdx, side: Side, price: Price) -> Self {
+        Self { asset, side, price }
+    }
+}
+
+impl MarketAgent for MarketTestAgent {
+    fn update<R: RngCore, const M: usize, const N: usize>(
+        &mut self,
+        env: &mut MarketEnv<M, N>,
+        _rng: &mut R,
+    ) {
+        env.place_order(self.asset, self.side, 10, 101, Some(self.price))
+            .unwrap();
+    }
+}
+
+#[test]
+fn test_market_agent_macro() {
+    #[derive(MarketAgentSet)]
+    struct TestAgents {
+        pub a: MarketTestAgent,
+        pub b: MarketTestAgent,
+        pub c: MarketTestAgent,
+        pub d: MarketTestAgent,
+    }
+
+    let mut env = MarketEnv::<2>::new(0, [1, 1], 1000, true);
+    let mut rng = Xoroshiro128StarStar::seed_from_u64(101);
+
+    let mut test_agents = TestAgents {
+        a: MarketTestAgent::new(0, Side::Bid, 20),
+        b: MarketTestAgent::new(0, Side::Ask, 40),
+        c: MarketTestAgent::new(1, Side::Bid, 60),
+        d: MarketTestAgent::new(1, Side::Ask, 80),
+    };
+
+    test_agents.update(&mut env, &mut rng);
+    env.step(&mut rng);
+
+    assert!(env.get_market().ask_vols() == [10, 10]);
+    assert!(env.get_market().bid_vols() == [10, 10]);
+    assert!(env.get_market().bid_asks() == [(20, 40), (60, 80)]);
+
+    test_agents.update(&mut env, &mut rng);
+    env.step(&mut rng);
+
+    assert!(env.get_market().ask_vols() == [20, 20]);
+    assert!(env.get_market().bid_vols() == [20, 20]);
+    assert!(env.get_market().bid_asks() == [(20, 40), (60, 80)]);
 }


### PR DESCRIPTION
Add support for multi-asset simulations as part of the Rust API

- Add `Market` class to `bourse-book` crate that wraps multiple order-books and functionality to return market data and order instructions across assets
- Add `MarketEnv` discrete event simulation environment that wraps an environment and supports simulations across multiple assets